### PR TITLE
perf: enable scalar auto vectorization

### DIFF
--- a/CHANGELOG_OSDI.md
+++ b/CHANGELOG_OSDI.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added errors for branches with incompatible disciplines.
 * Statically integrate the `lld` linker and C runtime shims to remove any external dependencies.
 * Added `--print-expansion` CLI option to print the preprocessed file.
+* Enable LLVM Scalar Vectorization to automatically use SIMD instructions where possible.
 
 ### Fixed
 

--- a/CHANGELOG_VERILOGAE.md
+++ b/CHANGELOG_VERILOGAE.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added errors for branches with incompatible disciplines.
 * Statically integrate the `lld` linker and C runtime shims to remove any external dependencies.
+* Enable LLVM Scalar Vectorization to automatically use SIMD instructions where possible.
 
 ### Fixed
 

--- a/openvaf/llvm/src/lib.rs
+++ b/openvaf/llvm/src/lib.rs
@@ -158,7 +158,7 @@ pub enum TargetData {}
 pub enum TargetMachine {}
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum OptLevel {
     None = 0,
     Less = 1,

--- a/openvaf/llvm/src/pass_manager.rs
+++ b/openvaf/llvm/src/pass_manager.rs
@@ -15,6 +15,7 @@ extern "C" {
 
     fn LLVMPassManagerBuilderSetOptLevel(PMB: &PassManagerBuilder, OptLevel: c_uint);
     pub fn LLVMPassManagerBuilderSetSizeLevel(PMB: &PassManagerBuilder, SizeLevel: c_uint);
+    fn LLVMPassManagerBuilderSLPVectorize(PMB: &PassManagerBuilder);
 
     pub fn LLVMPassManagerBuilderSetDisableUnitAtATime(PMB: &PassManagerBuilder, Value: Bool);
     pub fn LLVMPassManagerBuilderSetDisableUnrollLoops(PMB: &PassManagerBuilder, Value: Bool);
@@ -43,7 +44,10 @@ extern "C" {
 /// This should always be save but this low level wrapper purposefully refrains from making Safety
 /// garantuees
 pub unsafe fn pass_manager_builder_set_opt_lvl(pmb: &PassManagerBuilder, opt_lvl: OptLevel) {
-    LLVMPassManagerBuilderSetOptLevel(pmb, opt_lvl as c_uint)
+    LLVMPassManagerBuilderSetOptLevel(pmb, opt_lvl as c_uint);
+    if opt_lvl > OptLevel::Less {
+        LLVMPassManagerBuilderSLPVectorize(pmb);
+    }
 }
 
 // Core->Pass managers

--- a/openvaf/llvm/wrapper/OpenVafWrapper.cpp
+++ b/openvaf/llvm/wrapper/OpenVafWrapper.cpp
@@ -2,10 +2,11 @@
 #include "llvm/Support/CrashRecoveryContext.h"
 #include <llvm/IR/Attributes.h>
 #include <llvm/IR/Function.h>
+#include <llvm/Transforms/IPO/PassManagerBuilder.h>
 
+#include <iostream>
 #include <mutex>
 #include <stdlib.h>
-#include <iostream>
 
 #include <lld/Common/Driver.h>
 
@@ -56,6 +57,11 @@ void LLVMPurgeAttrs(LLVMValueRef V) {
   }
 }
 
+void LLVMPassManagerBuilderSLPVectorize(LLVMPassManagerBuilderRef PMB) {
+  PassManagerBuilder *Builder = unwrap(PMB);
+  Builder->SLPVectorize = true;
+}
+
 enum LldFlavor {
   Elf = 0,
   MachO = 1,
@@ -101,7 +107,7 @@ LldInvokeResult lld_link(LldFlavor flavor, int argc, const char **argv) {
   // ensures reporduce binaries on linux. Done here instead of the main compiler
   // because the mutex ensure thread save behaviour with regard to env variables
   putenv(strdup("ZERO_AR_DATE=1"));
-  
+
   bool success = false;
   {
     // The crash recovery is here only to be able to recover from arbitrary
@@ -127,7 +133,7 @@ LldInvokeResult lld_link(LldFlavor flavor, int argc, const char **argv) {
     }
   }
   std::string resultMessage = errorString + outputString;
-  return {.ret_code = success?0: 1, .messages = lld_alloc_str(resultMessage)};
+  return {.ret_code = success ? 0 : 1,
+          .messages = lld_alloc_str(resultMessage)};
 }
 }
-


### PR DESCRIPTION
Enables LLVM auto vectorization for scalar code for a sizable performance boost.

OpenVAF benefits from this optimization in particular because:
* It compiles all code for the `native` CPU by default and is able to use all SIMD instructions.
* Compact models usually just perform ALOT of scalar floating point operations which are easy to vectorize.
