### PR TITLE
fix various small issues

### DIFF
--- a/CHANGELOG_OSDI.md
+++ b/CHANGELOG_OSDI.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Correctly detect file encoding.
 * Invocations of `$limit` that use user defined functions.
 * Correctly parse net declarations without attached discipline (usually `ground`).
+* Panic that occurs when a model contains no branch contributes.
 
 ## 22.12.0 - 2022-12-16
 

--- a/CHANGELOG_OSDI.md
+++ b/CHANGELOG_OSDI.md
@@ -4,6 +4,14 @@ All notable changes to OpenVAF relevant to OSDI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+
+* Correctly detect file encoding.
+* Invocations of `$limit` that use user defined functions.
+* Correctly parse net declarations without attached discipline (usually `ground`).
+
 ## 22.12.0 - 2022-12-16
 
 ### Added

--- a/CHANGELOG_OSDI.md
+++ b/CHANGELOG_OSDI.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Invocations of `$limit` that use user defined functions.
 * Correctly parse net declarations without attached discipline (usually `ground`).
 * Panic that occurs when a model contains no branch contributes.
+* Panic for voltage sources when the associated current is unused.
 
 ## 22.12.0 - 2022-12-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,12 @@ incremental = true
 panic = "abort"
 debug = true
 
+[profile.opt]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+opt-level = 3
+
 
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,

--- a/README.md
+++ b/README.md
@@ -56,11 +56,29 @@ Melange is currently in early development and most features are not complete.
 Some mockups of planned usage can be found in `melange/examples`.
 Some working minimal examples (in rust) can be found in `melange/core/test.rs`.
 
-## Building OpenVAF
+## Building OpenVAF using docker
 
-Building OpenVAF requires rust/cargo 1.63 (best installed with [rustup](https://rustup.rs/)).
+Building OpenVAF requires a specific version of LLVM-14 which can be difficult to install. We are working on simplifying the process.
+In the meantime it's recommended to use the official docker image for compiling openvaf. Simply run the following commands
+
+``` shell
+git clone https://github.com/pascalkuthe/OpenVAF.git && cd openvaf
+docker pull ghcr.io/pascalkuthe/ferris_ci_build_x86_64-unknown-linux-gnu:latest
+podman run -ti -v $(pwd):/io:Z ferris_ci_build_x86_64-unknown-linux-gnu:latest
+
+# Now you are inside the docker container
+cd /io
+cargo build --release
+# OpenVAF will be build this can take a while
+# afterwards the binary is available in target/release/openvaf
+# inside the repository 
+```
+
+## General Build Instructions 
+
+OpenVAF requires rust/cargo 1.63 (best installed with [rustup](https://rustup.rs/)).
 Furthermore, LLVM-14 development libraries and toolchain are required.
-Older versions are not supported and will produce compilation errors.
+Older or newever versions are not supported and will produce compilation errors.
 Newer version might work, however OpenVAF directly uses some internals of the `lld-linker` that may change between versions.
 OpenVAF requires the following components of the LLVM toolchain:
 
@@ -69,9 +87,10 @@ OpenVAF requires the following components of the LLVM toolchain:
 - lld development libraries
 - LLVM development libraries
 
-On fedora these can be installed with `sudo dnf install llvm-devel lld-devel`. 
+On fedora 37 these can be installed with `sudo dnf install llvm-devel lld-devel`. 
 On debian based distros the [llvm provided packages](https://apt.llvm.org/) can be used instead.
 Windows developers must compile LLVM themselves.
+
 Once all dependencies are satisfied you can build the entire project by running:
 
 ``` shell

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 <br>
 <br>
 
-
 OpenVAF is a Verilog-A compiler that can compile Verilog-A files for use in circuit simulator.
 The major aim of this Project is to provide a high-quality standard compliant compiler for Verilog-A.
 Furthermore, the project aims to bring modern compiler construction algorithms/data structures to a field with a lack of such tooling.
@@ -20,6 +19,9 @@ Some highlights of OpenVAF include:
 * **easy setup** (no runtime dependencies even for cross compilation)
 * **fast simulations** surpassing existing solutions by 30%-60%, often matching handwritten models
 * IDE aware design
+
+Detailed documentation, examples and precompiled binaries of all release are **available on our [website](https://openvaf.semimod.de)**. To test the latest development version you can download nightly version of OpenVAF for linux [here](https://openva.fra1.cdn.digitaloceanspaces.com/openvaf_devel_linux_amd64.tar.gz).
+
 
 ## Projects
 

--- a/openvaf/hir_ty/src/types.rs
+++ b/openvaf/hir_ty/src/types.rs
@@ -177,7 +177,7 @@ impl Ty {
             | (Ty::PortFlow(_), TyRequirement::PortFlow)
             | (Ty::Nature(_), TyRequirement::Nature)
             | (Ty::Param(_, _), TyRequirement::AnyParam)
-            | (Ty::BuiltInFunction, TyRequirement::Function)
+            | (Ty::UserFunction(_), TyRequirement::Function)
             | (Ty::Branch(_), TyRequirement::Branch) => true,
 
             (

--- a/openvaf/parser/src/grammar/items/module.rs
+++ b/openvaf/parser/src/grammar/items/module.rs
@@ -162,7 +162,7 @@ fn net_decl<const NET_TYPE_FIRST: bool>(p: &mut Parser, m: Marker) {
     //direction and type ar both optional since only one is required
     if NET_TYPE_FIRST {
         p.bump(NET_TYPE);
-        if !p.nth_at(1, T![,]) {
+        if !p.nth_at_ts(1, TokenSet::new(&[T![,], T![;]])) {
             eat_name_ref(p);
         }
     } else {

--- a/openvaf/sim_back/src/middle.rs
+++ b/openvaf/sim_back/src/middle.rs
@@ -113,14 +113,13 @@ impl EvalMir {
         gvn.remove_unnecessary_insts(&mut func, &dom_tree);
         gvn.clear(&mut func);
 
-        let mut output_block = {
-            let inst = intern
-                .outputs
-                .values()
-                .find_map(|val| val.expand().and_then(|val| func.dfg.value_def(val).inst()))
-                .unwrap();
-            func.layout.inst_block(inst).unwrap()
-        };
+        let mut output_block = intern
+            .outputs
+            .values()
+            .find_map(|val| val.expand().and_then(|val| func.dfg.value_def(val).inst()))
+            .map_or(func.layout.entry_block().unwrap(), |inst| {
+                func.layout.inst_block(inst).unwrap()
+            });
 
         output_values.clear();
         for (kind, val) in intern.outputs.iter() {

--- a/openvaf/sim_back/src/middle.rs
+++ b/openvaf/sim_back/src/middle.rs
@@ -264,6 +264,21 @@ impl EvalMir {
             output_values.remove(old_val);
             *out_val = val.into();
         }
+
+        // it's possible that the residual generated new op_dependent
+        // variables or that previous ones were removed so recompute them here
+        op_dependent.clear();
+        op_dependent.extend(intern.params.raw.iter().filter_map(|(param, &val)| {
+            if func.dfg.value_dead(val) {
+                return None;
+            }
+            if param.op_dependent() {
+                Some(val)
+            } else {
+                None
+            }
+        }));
+
         op_dependent_insts.clear();
         op_dependent_insts.ensure(func.dfg.num_insts());
         let mut has_bound_step = false;

--- a/openvaf/syntax/src/parsing/tree_builder.rs
+++ b/openvaf/syntax/src/parsing/tree_builder.rs
@@ -202,9 +202,10 @@ impl<'a> SyntaxTreeBuilder<'a> {
 
     fn do_token(&mut self, kind: SyntaxKind, span: CtxSpan) {
         let same_ctx = span.ctx == self.current_range.ctx;
-        let is_continous = same_ctx && span.range.end() == self.current_range.range.start();
-
-        if !is_continous {
+        let is_continous = same_ctx && span.range.start() == self.current_range.range.end();
+        if is_continous {
+            self.current_range.range = self.current_range.range.cover(span.range);
+        } else {
             let start = self.ranges.last().map_or(0.into(), |(range, _, _)| range.end());
             let range = TextRange::new(start, self.text_pos);
             let old_range = mem::replace(&mut self.current_range, span);

--- a/openvaf/syntax/src/parsing/tree_builder.rs
+++ b/openvaf/syntax/src/parsing/tree_builder.rs
@@ -69,8 +69,9 @@ impl<'a> SyntaxTreeBuilder<'a> {
             self.err_depth += 1
         } else if kind == SyntaxKind::ERROR {
             self.err_depth = 0
-        };
-        self.eat_trivias();
+        } else {
+            self.eat_trivias();
+        }
         self.inner.start_node(VerilogALanguage::kind_to_raw(kind));
     }
 
@@ -83,7 +84,7 @@ impl<'a> SyntaxTreeBuilder<'a> {
         if self.err_depth == 0 {
             if let Some(mut err) = self.last_error.take() {
                 if let SyntaxError::UnexpectedToken { span, panic_end, .. } = &mut err {
-                    if span.end() != self.text_pos {
+                    if span.end() < self.text_pos {
                         *panic_end = Some(self.text_pos);
                     }
                 }
@@ -228,123 +229,3 @@ impl<'a> SyntaxTreeBuilder<'a> {
         self.inner.token(VerilogALanguage::kind_to_raw(kind), text);
     }
 }
-
-// TODO this would be nice but is pretty complicated with src code switchting
-// fn n_attached_trivias<'a>(
-//     kind: SyntaxKind,
-//     trivias: impl Iterator<Item = (SyntaxKind, &'a str)>,
-// ) -> usize {
-//     match kind {
-//         NATURE_DECL | MODULE_DECL | DISCIPLINE_DECL => {
-//             let mut res = 0;
-//             let mut trivias = trivias.enumerate().peekable();
-
-//             while let Some((i, (kind, text))) = trivias.next() {
-//                 match kind {
-//                     WHITESPACE if text.contains("\n\n") => {
-//                         break;
-//                     }
-//                     COMMENT => {
-//                         res = i + 1;
-//                     }
-//                     _ => (),
-//                 }
-//             }
-//             res
-//         }
-//         _ => 0,
-//     }
-// }
-
-// #[derive(Debug)]
-// pub enum RawStep<'a> {
-//     Token { kind: SyntaxKind, text: &'a str },
-//     Enter { kind: SyntaxKind },
-//     Exit,
-//     Error { msg: &'a str, pos: usize },
-// }
-
-// struct Builder<'a, F> {
-//     tokens: &'a [preprocessor::Token],
-//     pos: usize,
-//     state: State,
-//     sm: &'a SourceMap,
-//     ranges: Vec<(TextRange, SourceContext, TextSize)>,
-//     current_range: CtxSpan,
-//     inner: SyntaxTreeBuilder
-// }
-
-// enum State {
-//     PendingEnter,
-//     Normal,
-//     PendingExit,
-// }
-
-// impl<F: FnMut(RawStep)> Builder<'_, F> {
-//     fn token(&mut self, kind: SyntaxKind) {
-//         match mem::replace(&mut self.state, State::Normal) {
-//             State::PendingEnter => unreachable!(),
-//             State::PendingExit => (self.sink)(RawStep::Exit),
-//             State::Normal => (),
-//         }
-//         self.eat_trivias();
-//         let span = self.tokens[self.pos].span;
-//         self.do_token(kind, span);
-//     }
-
-//     fn enter(&mut self, kind: SyntaxKind) {
-//         match mem::replace(&mut self.state, State::Normal) {
-//             State::PendingEnter => {
-//                 (self.sink)(RawStep::Enter { kind });
-//                 // No need to attach trivias to previous node: there is no
-//                 // previous node.
-//                 return;
-//             }
-//             State::PendingExit => (self.sink)(RawStep::Exit),
-//             State::Normal => (),
-//         }
-
-//         let n_trivias =
-//             (self.pos..self.lexed.len()).take_while(|&it| self.lexed.kind(it).is_trivia()).count();
-//         let leading_trivias = self.pos..self.pos + n_trivias;
-//         let n_attached_trivias = n_attached_trivias(
-//             kind,
-//             leading_trivias.rev().map(|it| (self.lexed.kind(it), self.lexed.text(it))),
-//         );
-//         self.eat_n_trivias(n_trivias - n_attached_trivias);
-//         (self.sink)(RawStep::Enter { kind });
-//         self.eat_n_trivias(n_attached_trivias);
-//     }
-
-//     fn exit(&mut self) {
-//         match mem::replace(&mut self.state, State::PendingExit) {
-//             State::PendingEnter => unreachable!(),
-//             State::PendingExit => (self.sink)(RawStep::Exit),
-//             State::Normal => (),
-//         }
-//     }
-
-//     fn eat_trivias(&mut self) {
-//         while self.pos < self.lexed.len() {
-//             let kind = self.lexed.kind(self.pos);
-//             if !kind.is_trivia() {
-//                 break;
-//             }
-//             self.do_token(kind, 1);
-//         }
-//     }
-
-//     fn eat_n_trivias(&mut self, n: usize) {
-//         for _ in 0..n {
-//             let kind = self.lexed.kind(self.pos);
-//             assert!(kind.is_trivia());
-//             self.do_token(kind, 1);
-//         }
-//     }
-
-//     fn do_token(&mut self, kind: SyntaxKind, span: CtxSpan) {
-//         let text = &self.lexed.range_text(self.pos..self.pos + n_tokens);
-//         self.pos += n_tokens;
-//         (self.sink)(RawStep::Token { kind, text });
-//     }
-// }


### PR DESCRIPTION
- fix $limit invocation with user-defined functions (fixes #13)
- fix: correctly parse net declarations without disciplines (fixes #17)
- fix panic for model without contributes
- fix: panic if op dependent parameters are added during residual generation (fixes #23)
- perf: avoid producing unnecessary text mappings
- fix regressed syntax errors
- add opt profile for releases
- add build instructions using the docker image
- link website and nightly version in README (addresses #21)
