### PR TITLE
Fix crashes in untested VA features

### DIFF
--- a/CHANGELOG_OSDI.md
+++ b/CHANGELOG_OSDI.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 * support for `analog initial` blocks
+* Allow ignoring errors when a port is declared without direction
 
 ## 23.2.0 - 2023-02-01
 

--- a/CHANGELOG_OSDI.md
+++ b/CHANGELOG_OSDI.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 * Allow parameter declaration without explicit types
+* Crash when using engineering real format specifier `%r`
 
 ## 23.2.0 - 2023-02-01
 

--- a/CHANGELOG_OSDI.md
+++ b/CHANGELOG_OSDI.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * support for `analog initial` blocks
 * Allow ignoring errors when a port is declared without direction
 
+## Fixed
+
+* Allow parameter declaration without explicit types
+
 ## 23.2.0 - 2023-02-01
 
 ## Breaking Changes

--- a/CHANGELOG_VERILOGAE.md
+++ b/CHANGELOG_VERILOGAE.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Swapped signatures for `slew` and `transition`
 * `aliasparam` declarations being ignored
 * Allow parameter declaration without explicit types
+* Crash when using engineering real format specifier `%r`
 
 ##  0.9.0-beta8 - 2022-07-19
 

--- a/CHANGELOG_VERILOGAE.md
+++ b/CHANGELOG_VERILOGAE.md
@@ -6,13 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.0 - 2023-02-01
+## [unreleased]
 
 ### Added
 
 * Added errors for branches with incompatible disciplines.
 * Statically integrate the `lld` linker and C runtime shims to remove any external dependencies.
 * Enable LLVM Scalar Vectorization to automatically use SIMD instructions where possible.
+* Allow parameter declaration without explicit types
 
 ### Fixed
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Crash when encountering potential/flow probe with no arguments
 * Swapped signatures for `slew` and `transition`
 * `aliasparam` declarations being ignored
+* Allow parameter declaration without explicit types
 
 ##  0.9.0-beta8 - 2022-07-19
 

--- a/openvaf/basedb/src/diagnostics.rs
+++ b/openvaf/basedb/src/diagnostics.rs
@@ -36,7 +36,10 @@ pub trait Diagnostic {
             let mut report = self.build_report(root_file, db);
 
             if is_default {
-                let hint = format!("{} is set to {} by default", name, lvl);
+                let hint = format!(
+                    "{} is set to {} by default\nuse a CLI argument or an attribute to overwrite",
+                    name, lvl
+                );
                 report.notes.push(hint)
             }
 

--- a/openvaf/basedb/src/lints.rs
+++ b/openvaf/basedb/src/lints.rs
@@ -50,6 +50,10 @@ pub struct LintSrc {
 }
 
 impl LintSrc {
+    pub fn item(ast: ErasedAstId) -> LintSrc {
+        Self { overwrite: None, ast: Some(ast) }
+    }
+
     pub fn lvl(&self, lint: Lint, root_file: FileId, db: &dyn BaseDB) -> (LintLevel, bool) {
         match self.overwrite {
             Some(lvl) => (lvl, false),
@@ -173,5 +177,6 @@ pub mod builtin {
         pub const non_standard_analog_operator = LintData{default_lvl: Deny, documentation_id: 13};
         pub const const_simparam = LintData{default_lvl: Allow, documentation_id: 14};
         pub const variant_const_simparam = LintData{default_lvl: Warn, documentation_id: 15};
+        pub const port_without_direction = LintData{default_lvl: Deny, documentation_id: 16};
     }
 }

--- a/openvaf/hir_def/src/data.rs
+++ b/openvaf/hir_def/src/data.rs
@@ -134,7 +134,7 @@ impl VarData {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParamData {
     pub name: Name,
-    pub ty: Type,
+    pub ty: Option<Type>,
 }
 
 impl ParamData {

--- a/openvaf/hir_def/src/item_tree.rs
+++ b/openvaf/hir_def/src/item_tree.rs
@@ -493,6 +493,7 @@ impl NodeTypeDecl {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Node {
     pub name: Name,
+    pub is_port: bool,
     pub ast_id: ErasedAstId,
     // TODO small vec?
     pub decls: Vec<NodeTypeDecl>,
@@ -500,7 +501,14 @@ pub struct Node {
 
 impl Node {
     pub fn direction(&self, tree: &ItemTree) -> (bool, bool) {
-        self.decls.iter().find_map(|decl| decl.direction(tree)).unwrap_or((false, false))
+        match self.decls.iter().find_map(|decl| decl.direction(tree)) {
+            Some(direction) => direction,
+            // default to inout to avoid confusing error messages
+            // and to allow omitting direction specification
+            // for backwards compatability with cadence, see #40
+            None if self.is_port => (true, true),
+            None => (false, false),
+        }
     }
 
     pub fn is_gnd(&self, tree: &ItemTree) -> bool {

--- a/openvaf/hir_def/src/item_tree.rs
+++ b/openvaf/hir_def/src/item_tree.rs
@@ -290,7 +290,7 @@ pub struct Var {
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Param {
     pub name: Name,
-    pub ty: Type,
+    pub ty: Option<Type>,
     pub is_local: bool,
     pub ast_id: AstId<ast::Param>,
 }

--- a/openvaf/hir_def/src/item_tree/lower.rs
+++ b/openvaf/hir_def/src/item_tree/lower.rs
@@ -371,6 +371,7 @@ impl Ctx {
                     if nodes.iter().all(|node| node.name != name) {
                         let node = nodes.push_and_get_key(Node {
                             name,
+                            is_port: true,
                             ast_id: ast_id.into(),
                             decls: Vec::new(),
                         });
@@ -412,6 +413,7 @@ impl Ctx {
                 None => {
                     let node = nodes.push_and_get_key(Node {
                         name,
+                        is_port: true,
                         ast_id: ast_id.into(),
                         decls: vec![id.into()],
                     });
@@ -446,6 +448,7 @@ impl Ctx {
                 None => {
                     let node = nodes.push_and_get_key(Node {
                         name,
+                        is_port: false,
                         ast_id: ast_id.into(),
                         decls: vec![id.into()],
                     });

--- a/openvaf/hir_def/src/item_tree/lower.rs
+++ b/openvaf/hir_def/src/item_tree/lower.rs
@@ -545,7 +545,7 @@ impl Ctx {
     }
 
     fn lower_param<T: From<ItemTreeId<Param>>>(&mut self, decl: ast::ParamDecl, dst: &mut Vec<T>) {
-        let ty = decl.ty().as_type();
+        let ty = decl.ty().map(|ty| ty.as_type());
         for param in decl.paras() {
             if let Some(name) = param.name() {
                 let ast_id = self.source_ast_id_map.ast_id(&param);

--- a/openvaf/hir_def/src/item_tree/pretty.rs
+++ b/openvaf/hir_def/src/item_tree/pretty.rs
@@ -157,7 +157,7 @@ impl<'a> Printer<'a> {
 
     fn print_parameter(&mut self, param: ItemTreeId<Param>) {
         let param = &self.tree[param];
-        wln!(self, "param {} {}", param.ty, param.name);
+        wln!(self, "param {} {}", param.ty.as_ref().unwrap_or(&crate::Type::Err), param.name);
     }
 
     fn print_var(&mut self, var: ItemTreeId<Var>) {

--- a/openvaf/hir_lower/src/body.rs
+++ b/openvaf/hir_lower/src/body.rs
@@ -260,14 +260,13 @@ impl HirInterner {
             let body = db.body(param.into());
             let infere = db.inference_result(param.into());
             let info = db.param_exprs(param);
-            let data = db.param_data(param).clone();
-            let ty = &data.ty;
+            let ty = db.param_ty(param);
 
             // create a temporary to hold onto the uses
             let new_val = builder.make_param(0u32.into());
             builder.func.dfg.replace_uses(param_val, new_val);
 
-            let ops = CmpOps::from_ty(ty);
+            let ops = CmpOps::from_ty(&ty);
 
             let (then_src, else_src) = builder.make_cond(param_given, |builder, param_given| {
                 if param_given {

--- a/openvaf/hir_lower/src/lib.rs
+++ b/openvaf/hir_lower/src/lib.rs
@@ -158,7 +158,7 @@ impl PlaceKind {
 
             PlaceKind::ImplicitResidual { .. } | PlaceKind::Contribute { .. } => Type::Real,
             PlaceKind::ParamMin(param) | PlaceKind::ParamMax(param) | PlaceKind::Param(param) => {
-                db.param_data(param).ty.clone()
+                db.param_ty(param)
             }
             PlaceKind::IsVoltageSrc(_) | PlaceKind::CollapseImplicitEquation(_) => Type::Bool,
         }

--- a/openvaf/hir_ty/src/inference.rs
+++ b/openvaf/hir_ty/src/inference.rs
@@ -1096,24 +1096,7 @@ impl Ctx<'_> {
                     if canditates.is_empty() {
                         canditates = new_candidates;
                     }
-                } else if canditates.is_empty() {
-                    let sig: Vec<_> =
-                        new_candidates.iter().map(|canditate| &signatures[*canditate]).collect();
-
-                    unreachable!(
-                        "ambigous signature {:#?} all match {:?} (nothing matches exactly...)",
-                        sig, arg_types
-                    );
                 }
-
-                /*if canditates.len() != 1 {
-                    let sig: Vec<_> =
-                        canditates.iter().map(|canditate| &signatures[*canditate]).collect();
-                    println!(
-                        "ambigous signature {:?} all match {:?} (using first variant)",
-                        sig, arg_types
-                    );
-                } else*/
 
                 canditates[0]
             }

--- a/openvaf/hir_ty/src/validation.rs
+++ b/openvaf/hir_ty/src/validation.rs
@@ -464,7 +464,7 @@ impl Diagnostic for BodyValidationDiagnosticWrapped<'_> {
                     }]);
 
                 res = res.with_notes(vec![
-                        "This function is part of the Verilog-A standard but currently not implemented by OpenVAF\nIf this function is important to your application, create an issue:\nhttps://gitlab.com/DSPOM/OpenVAF/-/issues/new".to_owned(),
+                        "This function is part of the Verilog-A standard but currently not implemented by OpenVAF\nIf this function is important to your application, create an issue:\nhttps://github.com/pascalkuthe/openvaf/issues/new".to_owned(),
                     ]);
 
                 res

--- a/openvaf/osdi/src/compilation_unit.rs
+++ b/openvaf/osdi/src/compilation_unit.rs
@@ -333,6 +333,7 @@ fn print_callback<'ll>(
                         2,
                         UNNAMED,
                     );
+                    let exp = LLVMBuildLoad2(llbuilder, cx.ty_real(), exp, UNNAMED);
                     let num = LLVMBuildFMul(llbuilder, val, exp, UNNAMED);
                     args.push(num);
                     let scale_char = LLVMBuildInBoundsGEP2(

--- a/openvaf/parser/src/grammar/items.rs
+++ b/openvaf/parser/src/grammar/items.rs
@@ -96,7 +96,7 @@ fn var(p: &mut Parser) -> bool {
 
 pub(super) fn parameter_decl(p: &mut Parser, m: Marker) {
     p.bump_any();
-    ty(p);
+    eat_ty(p);
     decl_list(p, T![;], parameter, MODULE_ITEM_OR_ATTR_RECOVERY);
     p.eat(T![;]);
     m.complete(p, PARAM_DECL);

--- a/openvaf/sim_back/src/compilation_db.rs
+++ b/openvaf/sim_back/src/compilation_db.rs
@@ -370,7 +370,7 @@ impl ModuleInfo {
                 let range = ast.syntax().text_range();
 
                 let resolve_param_info = || {
-                    let ty = db.param_data(param).ty.clone();
+                    let ty = db.param_ty(param);
                     let type_ = resolve_str_attr(sink, &ast, "type");
                     let is_instance = match type_.as_deref() {
                         Some("instance") => true,

--- a/openvaf/syntax/veriloga.ungram
+++ b/openvaf/syntax/veriloga.ungram
@@ -212,7 +212,7 @@ Var =
 
 
 ParamDecl =
-  AttrList* ('parameter'|'localparam') Type paras:(Param (',' Param)*) ';'
+  AttrList* ('parameter'|'localparam') Type? paras:(Param (',' Param)*) ';'
 
 AliasParam =
   AttrList* 'aliasparam' name: Name '=' src: ParamRef ';'

--- a/openvaf/test_data/mir/analog_inital.mir
+++ b/openvaf/test_data/mir/analog_inital.mir
@@ -1,0 +1,16 @@
+function %(v16, v19, v22) {
+    v15 = iconst 2
+    v20 = iconst 3
+                                block0:
+@0004                               v17 = imul v15, v16
+@0004                               v18 = ifcast v17
+@0006                               v21 = ifcast v20
+@0002                               v23 = ifcast v16
+@0004                               v24 = fadd v23, v18
+@0006                               v25 = fadd v24, v21
+                                    v26 = optbarrier v18
+                                    v27 = optbarrier v25
+                                    jmp block1
+
+                                block1:
+}

--- a/openvaf/test_data/mir/analog_inital.va
+++ b/openvaf/test_data/mir/analog_inital.va
@@ -1,0 +1,15 @@
+`include "disciplines.va"
+
+module test;
+    parameter integer foo = 0;
+	electrical a,b;
+    real test;
+    real test2;
+    analog begin
+        test2 = foo + test + test2;
+    end
+    analog initial begin
+        test = 2 * foo;
+        test2 = 3;
+    end
+endmodule

--- a/openvaf/test_data/syn_ui/overwrite_reserved_ident.log
+++ b/openvaf/test_data/syn_ui/overwrite_reserved_ident.log
@@ -7,6 +7,7 @@ warning[L012]: reserved keyword 'cmos' was used as an identifier
   = 'cmos' will likely never be used in the implemented language subset so this use is allowed
   = to maintain compatibility with the VAMS standard this should be renamed
   = vams_keyword_compat is set to warn by default
+    use a CLI argument or an attribute to overwrite
 
 error[L012]: reserved keyword 'cmos' was used as an identifier
   ┌─ /overwrite_reserved_ident.va:5:46

--- a/openvaf/test_data/syn_ui/unkown_lint.log
+++ b/openvaf/test_data/syn_ui/unkown_lint.log
@@ -6,6 +6,7 @@ error[L008]: unknown lint 'bar'
   │
   = help: this attribute has no effect
   = lint_not_found is set to deny by default
+    use a CLI argument or an attribute to overwrite
 
 error[L008]: unknown lint 'foo'
   ┌─ /unkown_lint.va:2:25
@@ -15,4 +16,5 @@ error[L008]: unknown lint 'foo'
   │
   = help: this attribute has no effect
   = lint_not_found is set to deny by default
+    use a CLI argument or an attribute to overwrite
 

--- a/openvaf/test_data/ui/ddx.log
+++ b/openvaf/test_data/ui/ddx.log
@@ -10,6 +10,7 @@ warning[L011]: unkown supplied to the ddx operator is not standard compilant
      branch current acces: I(branch), I(a,b)
      node voltage: V(x)
    = non_standard_code is set to warn by default
+     use a CLI argument or an attribute to overwrite
 
 error: invalid unkown was supplied to the ddx operator
    ┌─ /ddx.va:19:21

--- a/openvaf/test_data/ui/param_ty.log
+++ b/openvaf/test_data/ui/param_ty.log
@@ -1,0 +1,24 @@
+error: type missmatch: expected integer value but found real parameter ref
+   ┌─ /param_ty.va:11:10
+   │
+11 │         err = ~infer_real + ~explicit_real1 + ~explicit_real2 + infer_string;
+   │                ^^^^^^^^^^ expected integer value
+
+error: type missmatch: expected integer value but found real parameter ref
+   ┌─ /param_ty.va:11:24
+   │
+11 │         err = ~infer_real + ~explicit_real1 + ~explicit_real2 + infer_string;
+   │                              ^^^^^^^^^^^^^^ expected integer value
+
+error: type missmatch: expected integer value but found real parameter ref
+   ┌─ /param_ty.va:11:42
+   │
+11 │         err = ~infer_real + ~explicit_real1 + ~explicit_real2 + infer_string;
+   │                                                ^^^^^^^^^^^^^^ expected integer value
+
+error: type missmatch: expected integer value or real value but found string parameter ref
+   ┌─ /param_ty.va:11:59
+   │
+11 │         err = ~infer_real + ~explicit_real1 + ~explicit_real2 + infer_string;
+   │                                                                 ^^^^^^^^^^^^ expected integer value or real value
+

--- a/openvaf/test_data/ui/param_ty.va
+++ b/openvaf/test_data/ui/param_ty.va
@@ -1,0 +1,14 @@
+module param_ty;
+	parameter real explicit_real1 = 0.0;
+	parameter real explicit_real2 = 0;
+	parameter integer explicit_int1 = 0.0;
+	parameter integer explicit_int2 = 0;
+	parameter infer_int = 0;
+	parameter infer_real = 0.0;
+	parameter infer_string = "string";
+	real err, ok;
+	analog begin
+		err = ~infer_real + ~explicit_real1 + ~explicit_real2 + infer_string;
+		ok = ~infer_int + ~explicit_int1 + ~explicit_int2;
+	end
+endmodule

--- a/openvaf/test_data/ui/port_without_direction.log
+++ b/openvaf/test_data/ui/port_without_direction.log
@@ -1,0 +1,20 @@
+error[L016]: no direction declared for port 'x'
+  ┌─ /port_without_direction.va:3:14
+  │
+3 │ module error(x);
+  │              ^ 'x' is declared here without direction
+  │
+  = if port_without_direction is set to warn/allow the direciton will be set to 'inout'.
+  = note: port directions are always required by the language standard.
+  = port_without_direction is set to deny by default
+    use a CLI argument or an attribute to overwrite
+
+warning[L016]: no direction declared for port 'x'
+  ┌─ /port_without_direction.va:8:16
+  │
+8 │ module warning(x);
+  │                ^ 'x' is declared here without direction
+  │
+  = if port_without_direction is set to warn/allow the direciton will be set to 'inout'.
+  = note: port directions are always required by the language standard.
+

--- a/openvaf/test_data/ui/port_without_direction.va
+++ b/openvaf/test_data/ui/port_without_direction.va
@@ -1,0 +1,10 @@
+`include "disciplines.va"
+
+module error(x);
+    electrical x;
+endmodule
+
+(* openvaf_warn = "port_without_direction" *)
+module warning(x);
+    electrical x;
+endmodule

--- a/verilogae/verilogae/src/back.rs
+++ b/verilogae/verilogae/src/back.rs
@@ -4,6 +4,7 @@ use camino::Utf8Path;
 use hir_def::db::HirDefDB;
 use hir_def::Type;
 use hir_lower::{CallBackKind, CurrentKind, HirInterner, ParamInfoKind, ParamKind, PlaceKind};
+use hir_ty::db::HirTyDB;
 use lasso::Rodeo;
 use llvm::{OptLevel, UNNAMED};
 use mir::{ControlFlowGraph, FuncRef, Function};
@@ -112,7 +113,7 @@ impl<'ll> Codegen<'_, '_, 'll> {
     unsafe fn read_str_params(&mut self, ptr: &'ll llvm::Value) {
         let params = self.intern.live_params(&self.func.dfg).filter_map(|(id, kind, _)| {
             if let ParamKind::Param(param) = *kind {
-                (self.db.param_data(param).ty == Type::String).then_some((id, param))
+                (self.db.param_ty(param) == Type::String).then_some((id, param))
             } else {
                 None
             }
@@ -131,7 +132,7 @@ impl<'ll> Codegen<'_, '_, 'll> {
     unsafe fn read_params(&mut self, offset: &'ll llvm::Value, ptr: &'ll llvm::Value, ty: Type) {
         let params = self.intern.live_params(&self.func.dfg).filter_map(|(id, kind, _)| {
             if let ParamKind::Param(param) = kind {
-                (self.db.param_data(*param).ty == ty).then_some((id, *param))
+                (self.db.param_ty(*param) == ty).then_some((id, *param))
             } else {
                 None
             }

--- a/verilogae/verilogae/src/compiler_db.rs
+++ b/verilogae/verilogae/src/compiler_db.rs
@@ -449,7 +449,7 @@ impl ModelInfo {
                 let range = ast.syntax().text_range();
 
                 let resolve_param_info = || {
-                    let ty = db.param_data(param).ty.clone();
+                    let ty = db.param_ty(param);
                     if !matches!(ty, Type::Real | Type::Integer | Type::String) {
                         sink.add_diagnostic(
                             &IllegalType { range, allowed: "real, integer and string parameters" },


### PR DESCRIPTION
- Add tests for `analog initial` statements.
- Generate lint for ports without direction (see #40).
- Improve lint messages.
- Allow parameter declarations without explicit type (fixes #46).
- Fix some errors causing a panic during type inference.
- Fix outdated issue link.
- Fix crash when for %r format specifier.
