### PR TITLE
Prepare for release 23.5.0

### DIFF
--- a/CHANGELOG_OSDI.md
+++ b/CHANGELOG_OSDI.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Crash on windows when calling $display (missing osdi_log symbol)
 * `idt` operator not working (reactive dimension was undefined)
 * incorrect `param_given` results after setting instance paramters on the model struct.
+* Panic when accessing current probe that always returns 0
 
 ## 23.2.0 - 2023-02-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,10 +50,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.68"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "arc-swap"
@@ -141,6 +190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
+
+[[package]]
 name = "bitset"
 version = "0.0.0"
 dependencies = [
@@ -150,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 
 [[package]]
 name = "cc"
@@ -179,25 +234,31 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
- "bitflags",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags 1.3.2",
  "clap_lex",
- "is-terminal",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "cli-table"
@@ -220,6 +281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,9 +294,9 @@ checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -237,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -248,22 +315,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -341,13 +408,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -362,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "expect-test"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4661aca38d826eb7c72fe128e4238220616de4c0cc00db7bfc38e2e1364dd3"
+checksum = "30d9eafeadd538e68fb28016364c9732d78e420b9ff8853fa5e4058861e9f8d3"
 dependencies = [
  "dissimilar",
  "once_cell",
@@ -381,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -410,8 +477,14 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -440,6 +513,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hir_def"
@@ -508,9 +587,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -518,24 +597,25 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -560,12 +640,12 @@ dependencies = [
 
 [[package]]
 name = "lasso"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb7b21a526375c5ca55f1a6dfd4e1fad9fa4edd750f530252a718a44b2608f0"
+checksum = "4badc7a606a3096e40b886fb2f63803cacf11cd79796ae04e3f4b7e35a38cfc2"
 dependencies = [
- "ahash 0.7.6",
- "hashbrown 0.11.2",
+ "ahash 0.8.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -579,25 +659,25 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.30"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
+checksum = "f4ac0e912c8ef1b735e92369695618dc5b1819f5a7bf3f167301a3ba1cea515e"
 dependencies = [
  "cc",
  "libc",
@@ -615,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "list_pool"
@@ -666,7 +746,7 @@ version = "0.0.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
- "bitflags",
+ "bitflags 2.2.1",
  "camino",
  "cli-table",
  "directories-next",
@@ -692,27 +772,18 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "mimalloc"
-version = "0.1.34"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
+checksum = "4e2894987a3459f3ffb755608bd82188f8ed00d0ae077f1edea29c068d639d98"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -815,7 +886,7 @@ dependencies = [
  "ahash 0.8.3",
  "bitset",
  "expect-test",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
  "indexmap",
  "mir",
  "mir_reader",
@@ -858,7 +929,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -873,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -919,12 +990,6 @@ dependencies = [
  "path-absolutize",
  "termcolor",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "osdi"
@@ -992,18 +1057,18 @@ dependencies = [
 
 [[package]]
 name = "path-absolutize"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1d4993b16f7325d90c18c3c6a3327db7808752db8d208cea0acee0abd52c52"
+checksum = "43eb3595c63a214e1b37b44f44b0a84900ef7ae0b4c5efce59e123d246d7a0de"
 dependencies = [
  "path-dedot",
 ]
 
 [[package]]
 name = "path-dedot"
-version = "3.0.18"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a81540d94551664b72b72829b12bd167c73c9d25fbac0e04fafa8023f7e4901"
+checksum = "9d55e486337acb9973cdea3ec5638c1b3bcb22e573b2b7b41969e0c744d5a15e"
 dependencies = [
  "once_cell",
 ]
@@ -1037,18 +1102,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.17.3"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
+checksum = "9cb946f5ac61bb61a5014924910d936ebd2b23b705f7a4a3c40b05c720b079a3"
 dependencies = [
  "once_cell",
  "python3-dll-a",
@@ -1057,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.17.3"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
+checksum = "fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1076,18 +1141,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1101,7 +1166,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1134,13 +1199,13 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "rowan"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5811547e7ba31e903fe48c8ceab10d40d70a101f3d15523c847cce91aa71f332"
+checksum = "64449cfef9483a475ed56ae30e2da5ee96448789fb2aa240a04beb6a055078bf"
 dependencies = [
  "countme",
  "hashbrown 0.12.3",
- "memoffset 0.6.5",
+ "memoffset",
  "rustc-hash",
  "text-size",
 ]
@@ -1159,16 +1224,16 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1204,7 +1269,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1251,9 +1316,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smol_str"
-version = "0.1.23"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7475118a28b7e3a2e157ce0131ba8c5526ea96e90ee601d9f6bb2e286a35ab44"
+checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
 
 [[package]]
 name = "sourcegen"
@@ -1281,9 +1346,20 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1314,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "termcolor"
@@ -1335,22 +1411,22 @@ checksum = "288cb548dbe72b652243ea797201f3d481a0609a967980fcc5b2315ea811560a"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1382,9 +1458,9 @@ checksum = "a3e5df347f0bf3ec1d670aad6ca5c6a1859cd9ea61d2113125794654ccced68f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1397,6 +1473,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "verilogae"
@@ -1508,84 +1590,135 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "workqueue"
@@ -1596,18 +1729,18 @@ dependencies = [
 
 [[package]]
 name = "xflags"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f14fe1ed41a5a2b5ef3f565586c4a8a559ee55d3953faab360a771135bdee00"
+checksum = "c4554b580522d0ca238369c16b8f6ce34524d61dafe7244993754bbd05f2c2ea"
 dependencies = [
  "xflags-macros",
 ]
 
 [[package]]
 name = "xflags-macros"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d11d5fc2a97287eded8b170ca80533b3c42646dd7fa386a5eb045817921022"
+checksum = "f58e7b3ca8977093aae6b87b6a7730216fc4c53a6530bab5c43a783cd810c1a8"
 
 [[package]]
 name = "xshell"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +79,30 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "base_n"
@@ -350,6 +389,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "hashbrown"
@@ -680,6 +725,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mir"
 version = "0.0.0"
 dependencies = [
@@ -809,6 +863,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,9 +904,11 @@ dependencies = [
 
 [[package]]
 name = "openvaf-driver"
-version = "23.2.0"
+version = "23.5.0"
 dependencies = [
  "anyhow",
+ "backtrace",
+ "backtrace-ext",
  "camino",
  "clap",
  "directories-next",
@@ -1079,6 +1144,12 @@ dependencies = [
  "rustc-hash",
  "text-size",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +288,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +454,12 @@ dependencies = [
  "syntax",
  "typed-index-collections",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
@@ -720,6 +748,7 @@ dependencies = [
  "lasso",
  "libc",
  "llvm",
+ "log",
  "mir",
  "target",
  "typed-index-collections",
@@ -818,6 +847,8 @@ dependencies = [
  "camino",
  "clap",
  "directories-next",
+ "env_logger",
+ "log",
  "mimalloc",
  "openvaf",
  "path-absolutize",
@@ -845,6 +876,7 @@ dependencies = [
  "indexmap",
  "lasso",
  "llvm",
+ "log",
  "mini_harness",
  "mir",
  "mir_interpret",
@@ -1017,6 +1049,23 @@ dependencies = [
  "redox_syscall",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "rowan"

--- a/lib/mini_harness/Cargo.toml
+++ b/lib/mini_harness/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/pascalkuthe/OpenVAF/tree/master/libs/dirtest"
 doctest = false
 
 [dependencies]
-xflags = "0.2"
+xflags = "0.3"

--- a/lib/mini_harness/src/flags.rs
+++ b/lib/mini_harness/src/flags.rs
@@ -5,11 +5,9 @@ xflags::xflags! {
 
     /// Run custom build command.
     cmd test
-    /// Filter string. Only tests which contain this string are run.
-    optional filter: String
     {
-        //print this help message
-        optional -h, --help
+        /// Filter string. Only tests which contain this string are run.
+        optional filter: String
         /// Run ignored and non-ignored tests.
         optional --include_ignored
         /// Run only ignored tests.
@@ -39,7 +37,6 @@ xflags::xflags! {
 pub struct Test {
     pub filter: Option<String>,
 
-    pub help: bool,
     pub include_ignored: bool,
     pub ignored: bool,
     pub list: bool,
@@ -50,7 +47,10 @@ pub struct Test {
 }
 
 impl Test {
-    pub const HELP: &'static str = Self::HELP_;
+    #[allow(dead_code)]
+    pub fn from_env_or_exit() -> Self {
+        Self::from_env_or_exit_()
+    }
 
     #[allow(dead_code)]
     pub fn from_env() -> xflags::Result<Self> {

--- a/lib/mini_harness/src/lib.rs
+++ b/lib/mini_harness/src/lib.rs
@@ -100,10 +100,6 @@ impl<M: fmt::Display> From<M> for Failed {
 impl Arguments {
     pub fn parse_cli() -> Arguments {
         match Arguments::from_env() {
-            Ok(res) if res.help => {
-                println!("{}", Arguments::HELP);
-                exit(0)
-            }
             Ok(res) => res,
             Err(err) => {
                 eprintln!("{err}");

--- a/melange/core/Cargo.toml
+++ b/melange/core/Cargo.toml
@@ -15,17 +15,17 @@ anyhow = "1"
 stdx = { version = "0.0.0", path = "../../lib/stdx" }
 typed_indexmap = { version = "0.0.0", path = "../../lib/typed_indexmap" }
 typed-index-collections = "3.1"
-camino = "1.1.2"
+camino = "1.1.4"
 indexmap = "1.9"
-lasso = { version = "0.6", features = ["ahash"] }
+lasso = { version = "0.7", features = ["ahash"] }
 klu-rs = "0.4.0"
 num-complex = "0.4.3"
 openvaf = { version = "0.1.2", path = "../../openvaf/openvaf" }
 
 directories-next = "2"
 libc = "0.2"
-libloading = "0.7"
+libloading = "0.8"
 log = "0.4.17"
 cli-table = { version = "0.4.7", default-features = false }
 pretty_dtoa = "0.3.0"
-bitflags = "1.3.2"
+bitflags = "2.2.1"

--- a/openvaf/basedb/src/lints.rs
+++ b/openvaf/basedb/src/lints.rs
@@ -178,5 +178,6 @@ pub mod builtin {
         pub const const_simparam = LintData{default_lvl: Allow, documentation_id: 14};
         pub const variant_const_simparam = LintData{default_lvl: Warn, documentation_id: 15};
         pub const port_without_direction = LintData{default_lvl: Deny, documentation_id: 16};
+        pub const trivial_probe = LintData{default_lvl: Warn, documentation_id: 17};
     }
 }

--- a/openvaf/hir_def/src/lib.rs
+++ b/openvaf/hir_def/src/lib.rs
@@ -284,7 +284,7 @@ pub struct NodeLoc {
 
 pub type LocalNodeId = Idx<Node>;
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Hash)]
 pub struct NodeId(salsa::InternId);
 
 impl_debug_display!(match NodeId{ NodeId(id) => "node{:?}", id;});

--- a/openvaf/hir_lower/Cargo.toml
+++ b/openvaf/hir_lower/Cargo.toml
@@ -23,7 +23,7 @@ mir_build = {version = "0.0.0", path = "../mir_build" }
 ahash = "0.8"
 typed-index-collections = "3.1"
 indexmap = "1.9"
-lasso = {version = "0.6", features = ["ahash"]}
+lasso = {version = "0.7", features = ["ahash"]}
 
 [dev-dependencies]
 salsa = "0.17.0-pre.2"

--- a/openvaf/hir_ty/Cargo.toml
+++ b/openvaf/hir_ty/Cargo.toml
@@ -30,7 +30,7 @@ salsa = "0.17.0-pre.2"
 typed-index-collections = "3.1"
 
 ahash = "0.8"
-smol_str = {version = "0.1.23", default_features=false}
+smol_str = {version = "0.2", default_features=false}
 
 
 [dev-dependencies]

--- a/openvaf/lexer/Cargo.toml
+++ b/openvaf/lexer/Cargo.toml
@@ -13,6 +13,6 @@ text-size = "1.1"
 tokens = {version="0.0.0", path="../tokens"}
 
 [dev-dependencies]
-expect-test = "1.4.0"
+expect-test = "1.4.1"
 
 

--- a/openvaf/linker/Cargo.toml
+++ b/openvaf/linker/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 [dependencies]
 target = { version = "0.0.0", path = "../target" }
 anyhow = "1"
-camino = "1.1.2"
+camino = "1.1.4"
 cc = "1.0.79"

--- a/openvaf/llvm/src/builder.rs
+++ b/openvaf/llvm/src/builder.rs
@@ -350,12 +350,6 @@ extern "C" {
     //     Destty: &'a Type,
     //     Name: *const c_char,
     // ) -> &'a Value;
-    pub fn LLVMBuildPointerCast<'a>(
-        builder: &Builder<'a>,
-        Val: &'a Value,
-        Destty: &'a Type,
-        Name: *const c_char,
-    ) -> &'a Value;
     pub fn LLVMBuildIntCast2<'a>(
         builder: &Builder<'a>,
         Val: &'a Value,
@@ -407,8 +401,10 @@ extern "C" {
         Val: &'a Value,
         Name: *const c_char,
     ) -> &'a Value;
-    pub fn LLVMBuildPtrDiff<'a>(
+
+    pub fn LLVMBuildPtrDiff2<'a>(
         builder: &Builder<'a>,
+        elem_ty: &'a Type,
         LHS: &'a Value,
         RHS: &'a Value,
         Name: *const c_char,

--- a/openvaf/llvm/src/types.rs
+++ b/openvaf/llvm/src/types.rs
@@ -69,7 +69,7 @@ extern "C" {
     //pub fn LLVMIsLiteralStruct(struct_ty: &Type) -> Bool;
 
     //// Core->Types->Sequential
-    pub fn LLVMGetElementType<'a>(ty: &'a Type) -> &'a Type;
+    // pub fn LLVMGetElementType<'a>(ty: &'a Type) -> &'a Type;
     ///// Get the subtypes of the given type.
     //pub fn LLVMGetSubtypes<'a>(ty: &'a Type, arr: *mut &'a Type);
     ///// Return the number of types in the derived type.

--- a/openvaf/llvm/src/values.rs
+++ b/openvaf/llvm/src/values.rs
@@ -156,7 +156,8 @@ extern "C" {
     // pub fn LLVMConstShl(LHSConstant: &'a Value, RHSConstant: &'a Value) -> &'a Value;
     // pub fn LLVMConstLShr(LHSConstant: &'a Value, RHSConstant: &'a Value) -> &'a Value;
     // pub fn LLVMConstAShr(LHSConstant: &'a Value, RHSConstant: &'a Value) -> &'a Value;
-    pub fn LLVMConstGEP<'a>(
+    pub fn LLVMConstInBoundsGEP2<'a>(
+        elem_ty: &'a Type,
         ConstantVal: &'a Value,
         ConstantIndices: *const &'a Value,
         NumIndices: c_uint,
@@ -194,7 +195,7 @@ extern "C" {
     // pub fn LLVMConstZExtOrBitCast(ConstantVal: &'a Value, ToType: TypeRef) -> &'a Value;
     // pub fn LLVMConstSExtOrBitCast(ConstantVal: &'a Value, ToType: TypeRef) -> &'a Value;
     // pub fn LLVMConstTruncOrBitCast(ConstantVal: &'a Value, ToType: TypeRef) -> &'a Value;
-    pub fn LLVMConstPointerCast<'a>(const_val: &'a Value, ty: &'a Type) -> &'a Value;
+    // pub fn LLVMConstPointerCast<'a>(const_val: &'a Value, ty: &'a Type) -> &'a Value;
     // pub fn LLVMConstIntCast<'a>(
     //     ConstantVal: &'a Value,
     //     ToType: &'a Type,

--- a/openvaf/mir/Cargo.toml
+++ b/openvaf/mir/Cargo.toml
@@ -14,7 +14,7 @@ stdx = {version = "0.0.0", path = "../../lib/stdx" }
 bforest = {version = "0.0.0" , path = "../../lib/bforest"}
 list_pool = {version = "0.0.0" , path = "../../lib/list_pool"}
 typed-index-collections = "3.1"
-lasso = {version = "0.6", features = ["ahash"]}
+lasso = {version = "0.7", features = ["ahash"]}
 ahash = "0.8"
 bitset = {version = "0.0.0", path = "../../lib/bitset" }
 typed_indexmap = { version = "0.0.0", path = "../../lib/typed_indexmap" }

--- a/openvaf/mir_build/Cargo.toml
+++ b/openvaf/mir_build/Cargo.toml
@@ -18,7 +18,7 @@ bitset = {version = "0.0.0", path = "../../lib/bitset" }
 
 smallvec = {version = "1.10", features = ["const_new","union"]}
 typed-index-collections = "3.1"
-lasso = {version = "0.6", features = ["ahash"]}
+lasso = {version = "0.7", features = ["ahash"]}
 
 [dev-dependencies]
 expect-test = "1.4"

--- a/openvaf/mir_interpret/Cargo.toml
+++ b/openvaf/mir_interpret/Cargo.toml
@@ -13,4 +13,4 @@ doctest = false
 mir = {version = "0.0.0", path = "../mir" }
 
 typed-index-collections = "3.1"
-lasso = {version = "0.6", features = ["ahash"]}
+lasso = {version = "0.7", features = ["ahash"]}

--- a/openvaf/mir_llvm/Cargo.toml
+++ b/openvaf/mir_llvm/Cargo.toml
@@ -20,3 +20,4 @@ arrayvec = "0.7"
 ahash = "0.8"
 lasso = { version = "0.6", features = ["ahash"] }
 libc = "0.2"
+log = "0.4.17"

--- a/openvaf/mir_llvm/Cargo.toml
+++ b/openvaf/mir_llvm/Cargo.toml
@@ -18,6 +18,6 @@ base_n = {version = "1", path="../../lib/base_n"}
 typed-index-collections = "3.1"
 arrayvec = "0.7"
 ahash = "0.8"
-lasso = { version = "0.6", features = ["ahash"] }
+lasso = { version = "0.7", features = ["ahash"] }
 libc = "0.2"
 log = "0.4.17"

--- a/openvaf/mir_llvm/src/declarations.rs
+++ b/openvaf/mir_llvm/src/declarations.rs
@@ -176,8 +176,7 @@ impl<'a, 'll> CodegenCx<'a, 'll> {
             llvm::LLVMSetGlobalConstant(global, llvm::True);
             llvm::LLVMSetLinkage(global, llvm::Linkage::Internal);
         }
-
-        self.ptrcast(global, self.ptr_ty(elem_ty))
+        global
     }
 
     pub fn export_array(
@@ -197,7 +196,7 @@ impl<'a, 'll> CodegenCx<'a, 'll> {
 
         if add_cnt {
             let name = format!("{}.cnt", name);
-            self.export_val(&name, self.ty_isize(), self.const_usize(vals.len()), true);
+            self.export_val(&name, self.ty_size(), self.const_usize(vals.len()), true);
         }
 
         arr
@@ -224,7 +223,7 @@ impl<'a, 'll> CodegenCx<'a, 'll> {
         if add_cnt {
             let name = format!("{}.cnt", name);
             let arr_len = self
-                .define_global(&name, self.ty_isize())
+                .define_global(&name, self.ty_size())
                 .unwrap_or_else(|| unreachable!("symbol '{}' already defined", name));
 
             unsafe {

--- a/openvaf/mir_llvm/src/intrinsics.rs
+++ b/openvaf/mir_llvm/src/intrinsics.rs
@@ -24,9 +24,9 @@ impl<'a, 'll> CodegenCx<'a, 'll> {
         // let void = self.ty_void();
         let t_bool = self.ty_bool();
         let t_i32 = self.ty_int();
-        let t_isize = self.ty_isize();
-        let t_f64 = self.ty_real();
-        let t_str = self.ty_str();
+        let t_isize = self.ty_size();
+        let t_f64 = self.ty_double();
+        let t_str = self.ty_ptr();
 
         ifn!("llvm.pow.f64", fn(t_f64, t_f64) -> t_f64);
         ifn!("llvm.sqrt.f64", fn(t_f64) -> t_f64);

--- a/openvaf/mir_llvm/src/lib.rs
+++ b/openvaf/mir_llvm/src/lib.rs
@@ -132,11 +132,13 @@ impl Drop for LLVMBackend<'_> {
 
 extern "C" fn diagnostic_handler(info: &llvm::DiagnosticInfo, _: *mut c_void) {
     let severity = unsafe { LLVMGetDiagInfoSeverity(info) };
-    if !cfg!(debug_assertions) && severity != llvm::DiagnosticSeverity::Error {
-        return;
-    }
     let msg = unsafe { LLVMString::new(LLVMGetDiagInfoDescription(info)) };
-    println!("LLVM({severity:?}): {msg}")
+    match severity {
+        llvm::DiagnosticSeverity::Error => log::error!("{msg}"),
+        llvm::DiagnosticSeverity::Warning => log::warn!("{msg}"),
+        llvm::DiagnosticSeverity::Remark => log::debug!("{msg}"),
+        llvm::DiagnosticSeverity::Note => log::trace!("{msg}"),
+    }
 }
 
 pub struct ModuleLlvm {

--- a/openvaf/mir_llvm/src/lib.rs
+++ b/openvaf/mir_llvm/src/lib.rs
@@ -119,7 +119,7 @@ impl<'t> LLVMBackend<'t> {
         literals: &'a Rodeo,
         module: &'ll ModuleLlvm,
     ) -> CodegenCx<'a, 'll> {
-        CodegenCx::new(literals, module, self.target, &self.target_cpu)
+        CodegenCx::new(literals, module, self.target)
     }
     pub fn target(&self) -> &'t Target {
         self.target

--- a/openvaf/mir_opt/Cargo.toml
+++ b/openvaf/mir_opt/Cargo.toml
@@ -18,7 +18,7 @@ bitset = {version = "0.0.0", path = "../../lib/bitset" }
 
 typed-index-collections = "3.1"
 ahash = "0.8"
-hashbrown = {version = "0.12", features = ["raw"]}
+hashbrown = {version = "0.13", features = ["raw"]}
 indexmap = "1.9"
 
 [dev-dependencies]

--- a/openvaf/mir_reader/Cargo.toml
+++ b/openvaf/mir_reader/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 mir = {version = "0.0.0", path = "../mir" }
 bforest = {version = "0.0.0" , path = "../../lib/bforest"}
-lasso = {version = "0.6", features = ["ahash"]}
+lasso = {version = "0.7", features = ["ahash"]}
 
 [dev-dependencies]
 expect-test = "1.4"

--- a/openvaf/openvaf-driver/Cargo.toml
+++ b/openvaf/openvaf-driver/Cargo.toml
@@ -19,5 +19,7 @@ path-absolutize = "3.0.14"
 anyhow = "1"
 termcolor = "1.2"
 camino = "1.1.2"
+env_logger = "0.10.0"
+log = "0.4.17"
 
 mimalloc = { version = "*", default-features = false}

--- a/openvaf/openvaf-driver/Cargo.toml
+++ b/openvaf/openvaf-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openvaf-driver"
-version = "23.2.0"
+version = "23.5.0"
 authors = ["DSPOM"]
 edition = "2021"
 license = "GPL-3.0"
@@ -21,5 +21,7 @@ termcolor = "1.2"
 camino = "1.1.2"
 env_logger = "0.10.0"
 log = "0.4.17"
+backtrace-ext = "0.2.1"
+backtrace = "0.3.67"
 
 mimalloc = { version = "*", default-features = false}

--- a/openvaf/openvaf-driver/Cargo.toml
+++ b/openvaf/openvaf-driver/Cargo.toml
@@ -13,12 +13,12 @@ path = "src/main.rs"
 
 openvaf = { version = "0.1.2", path = "../openvaf" }
 
-clap = "4.1"
+clap = "4.2"
 directories-next = "2"
-path-absolutize = "3.0.14"
+path-absolutize = "3.1.0"
 anyhow = "1"
 termcolor = "1.2"
-camino = "1.1.2"
+camino = "1.1.4"
 env_logger = "0.10.0"
 log = "0.4.17"
 backtrace-ext = "0.2.1"

--- a/openvaf/openvaf-driver/src/crash_report.rs
+++ b/openvaf/openvaf-driver/src/crash_report.rs
@@ -1,0 +1,173 @@
+//! This module prints backtraces in case of panics
+//! Adapated from https://github.com/rust-cli/human-panic/blob/0ebcb91b29e3f23b3559ea49d931a493ed7c8139
+//! under MIT license
+
+use std::error::Error;
+use std::fmt::Write as FmtWrite;
+use std::panic::PanicInfo;
+use std::{env, fs::File, io::Write, path::Path, path::PathBuf};
+use std::{io, mem, panic};
+
+use backtrace::Backtrace;
+use backtrace_ext::short_frames_strict;
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+// Utility function which will handle dumping information to disk
+pub fn handle_dump(panic_info: &PanicInfo) -> Option<PathBuf> {
+    let mut expl = String::new();
+
+    #[cfg(feature = "nightly")]
+    let message = panic_info.message().map(|m| format!("{}", m));
+
+    #[cfg(not(feature = "nightly"))]
+    let message = match (
+        panic_info.payload().downcast_ref::<&str>(),
+        panic_info.payload().downcast_ref::<String>(),
+    ) {
+        (Some(s), _) => Some(s.to_string()),
+        (_, Some(s)) => Some(s.to_string()),
+        (None, None) => None,
+    };
+
+    let cause = match message {
+        Some(m) => m,
+        None => "Unknown".into(),
+    };
+
+    match panic_info.location() {
+        Some(location) => expl.push_str(&format!(
+            "Panic occurred in file '{}' at line {}\n",
+            location.file(),
+            location.line()
+        )),
+        None => expl.push_str("Panic location unknown.\n"),
+    }
+
+    let report = Report::new(expl, cause);
+
+    match report.persist() {
+        Ok(f) => Some(f),
+        Err(_) => {
+            eprintln!("{}", report.0);
+            None
+        }
+    }
+}
+
+pub fn install_panic_handler() {
+    // we want the normal panic handler for debugging
+    if cfg!(debug_assertions) {
+        return;
+    }
+
+    panic::set_hook(Box::new(move |info: &PanicInfo| {
+        let file_path = handle_dump(info);
+        print_msg(file_path).expect("printing error message to console failed");
+    }));
+}
+
+pub fn print_msg<P: AsRef<Path>>(file_path: Option<P>) -> io::Result<()> {
+    use std::io::Write as _;
+
+    let mut stderr = StandardStream::stderr(ColorChoice::Auto);
+    stderr.set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true))?;
+    writeln!(stderr, "OpenVAF encountered a problem and has crashed!")?;
+    stderr.set_color(ColorSpec::new().set_reset(true))?;
+    writeln!(
+        stderr,
+        "\nA log file has been generated at \"{}\".
+To help us fix the problem, please open an issue at https://github.com/pascalkuthe/OpenVAF/
+or send an email to pascal.kuthe@semimod.de and attach the log file.
+If possible please also attach the source file that OpenVAF was compiling.",
+        match file_path {
+            Some(fp) => format!("{}", fp.as_ref().display()),
+            None => "<Failed to store file to disk>".to_string(),
+        },
+    )?;
+    Ok(())
+}
+
+/// Contains metadata about the crash like the backtrace and
+/// information about the crate and operating system. Can
+/// be used to be serialized and persisted or printed as
+/// information to the user.
+#[derive(Debug)]
+struct Report(String);
+
+impl Report {
+    /// Create a new instance.
+    pub fn new(explanation: String, cause: String) -> Self {
+        let mut dst = String::new();
+        let _ = writeln!(dst, "OpenVAF {}", env!("CARGO_PKG_VERSION"));
+        if let Ok(args) = super::ARGS.lock() {
+            if let Some(args) = &*args {
+                let _ = writeln!(dst, "{:#?}", args);
+            }
+        }
+        let _ = write!(dst, "{explanation}{cause}");
+        //We take padding for address and extra two letters
+        //to padd after index.
+        const HEX_WIDTH: usize = mem::size_of::<usize>() + 2;
+        //Padding for next lines after frame's address
+        const NEXT_SYMBOL_PADDING: usize = HEX_WIDTH + 6;
+
+        for (frame, idx) in short_frames_strict(&Backtrace::new()) {
+            let ip = frame.ip();
+            if idx.start + 1 < idx.end {
+                let _ = write!(dst, "\n{:4}..{:4}: {ip:HEX_WIDTH$?}", idx.start, idx.end);
+            } else {
+                let _ = write!(dst, "\n{:4}: {ip:HEX_WIDTH$?}", idx.start);
+            }
+
+            let symbols = frame.symbols();
+            if symbols.is_empty() {
+                let _ = write!(dst, " - <unresolved>");
+                continue;
+            }
+
+            for (idx, symbol) in symbols.iter().enumerate() {
+                //Print symbols from this address,
+                //if there are several addresses
+                //we need to put it on next line
+                if idx != 0 {
+                    let _ = write!(dst, "\n{:1$}", "", NEXT_SYMBOL_PADDING);
+                }
+
+                if let Some(name) = symbol.name() {
+                    let _ = write!(dst, " - {name}");
+                } else {
+                    let _ = write!(dst, " - <unknown>");
+                }
+
+                //See if there is debug information with file name and line
+                if let (Some(file), Some(line)) = (symbol.filename(), symbol.lineno()) {
+                    let _ = write!(
+                        dst,
+                        "\n{:3$}at {}:{}",
+                        "",
+                        file.display(),
+                        line,
+                        NEXT_SYMBOL_PADDING
+                    );
+                }
+            }
+        }
+
+        Self(dst)
+    }
+
+    /// Write a file to disk.
+    pub fn persist(&self) -> Result<PathBuf, Box<dyn Error + 'static>> {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let tmp_dir = env::temp_dir();
+        let file_name = format!("openvaf-crash-{timestamp}.log");
+        let file_path = Path::new(&tmp_dir).join(file_name);
+        let mut file = File::create(&file_path)?;
+        file.write_all(self.0.as_bytes())?;
+        // TODO: include log
+        Ok(file_path)
+    }
+}

--- a/openvaf/openvaf-driver/src/main.rs
+++ b/openvaf/openvaf-driver/src/main.rs
@@ -23,6 +23,13 @@ pub fn main() {
     let matches = main_command().get_matches();
     let input: Utf8PathBuf = matches.get_one(INPUT).cloned().unwrap_or_else(Utf8PathBuf::new);
 
+    let env = env_logger::Env::default().filter("OPENVAF_LOG").write_style("OPENVAF_LOG_STYLE");
+    env_logger::Builder::new()
+        .format_timestamp(None)
+        .filter(Some("salsa"), log::LevelFilter::Off)
+        .filter_level(log::LevelFilter::Off)
+        .parse_env(env)
+        .init();
     match wrapped_main(matches) {
         Ok(err_code) => exit(err_code),
         Err(err) => {

--- a/openvaf/openvaf/Cargo.toml
+++ b/openvaf/openvaf/Cargo.toml
@@ -26,5 +26,5 @@ md5 = "0.7"
 
 anyhow = "1"
 termcolor = "1.2"
-camino = "1.1.2"
+camino = "1.1.4"
 

--- a/openvaf/openvaf/src/lib.rs
+++ b/openvaf/openvaf/src/lib.rs
@@ -21,6 +21,7 @@ pub use target::spec::{get_target_names, Target};
 
 mod cache;
 
+#[derive(Debug, Clone)]
 pub enum CompilationDestination {
     Path { lib_file: Utf8PathBuf },
     Cache { cache_dir: Utf8PathBuf },
@@ -31,6 +32,7 @@ pub enum CompilationTermination {
     FatalDiagnostic,
 }
 
+#[derive(Debug, Clone)]
 pub struct Opts {
     pub defines: Vec<String>,
     pub codegen_opts: Vec<String>,

--- a/openvaf/osdi/Cargo.toml
+++ b/openvaf/osdi/Cargo.toml
@@ -27,16 +27,16 @@ target = { version = "0.0.0", path = "../target"}
 
 typed-index-collections = "3.1"
 ahash = "0.8"
-lasso = {version = "0.6", features = ["ahash"]}
+lasso = {version = "0.7", features = ["ahash"]}
 
 salsa = "0.17.0-pre.2"
 indexmap = "1.9"
-smol_str = {version = "0.1.23", default_features=false}
+smol_str = {version = "0.2", default_features=false}
 
 base_n = {version = "1", path="../../lib/base_n"}
 rayon-core = "1"
 
-camino = "1.1.2"
+camino = "1.1.4"
 log = "0.4.17"
 
 [build-dependencies]

--- a/openvaf/osdi/Cargo.toml
+++ b/openvaf/osdi/Cargo.toml
@@ -37,7 +37,7 @@ base_n = {version = "1", path="../../lib/base_n"}
 rayon-core = "1"
 
 camino = "1.1.2"
-
+log = "0.4.17"
 
 [build-dependencies]
 

--- a/openvaf/osdi/src/eval.rs
+++ b/openvaf/osdi/src/eval.rs
@@ -135,7 +135,10 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
                             return loc.into();
                         }
 
-                        ParamKind::Current(kind) => prev_solve[&SimUnknown::Current(kind)],
+                        ParamKind::Current(kind) => prev_solve
+                            .get(&SimUnknown::Current(kind))
+                            .copied()
+                            .unwrap_or_else(|| cx.const_real(0.0)),
                         ParamKind::ImplicitUnknown(equation) => prev_solve
                             .get(&SimUnknown::Implicit(equation))
                             .copied()

--- a/openvaf/osdi/src/eval.rs
+++ b/openvaf/osdi/src/eval.rs
@@ -7,6 +7,7 @@ use llvm::{
     LLVMBuildOr, LLVMBuildRet, LLVMBuildStore, LLVMCreateBuilderInContext, LLVMDisposeBuilder,
     LLVMGetParam, LLVMPositionBuilderAtEnd, UNNAMED,
 };
+use log::info;
 use mir_llvm::{Builder, BuilderVal, CallbackFun, MemLoc};
 use sim_back::{BoundStepKind, SimUnknown};
 use typed_index_collections::TiVec;
@@ -138,11 +139,17 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
                         ParamKind::Current(kind) => prev_solve
                             .get(&SimUnknown::Current(kind))
                             .copied()
-                            .unwrap_or_else(|| cx.const_real(0.0)),
+                            .unwrap_or_else(|| {
+                                info!("current probe {kind:?} always returns zero");
+                                cx.const_real(0.0)
+                            }),
                         ParamKind::ImplicitUnknown(equation) => prev_solve
                             .get(&SimUnknown::Implicit(equation))
                             .copied()
-                            .unwrap_or_else(|| cx.const_real(0.0)),
+                            .unwrap_or_else(|| {
+                                info!("implict equation {equation} collapsed to zero");
+                                cx.const_real(0.0)
+                            }),
                         ParamKind::Temperature => {
                             return inst_data.temperature_loc(cx, instance).into()
                         }

--- a/openvaf/osdi/src/eval.rs
+++ b/openvaf/osdi/src/eval.rs
@@ -4,8 +4,8 @@ use llvm::IntPredicate::{IntNE, IntULT};
 use llvm::{
     LLVMAppendBasicBlockInContext, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildBr, LLVMBuildCall2,
     LLVMBuildCondBr, LLVMBuildICmp, LLVMBuildInBoundsGEP2, LLVMBuildIntCast2, LLVMBuildLoad2,
-    LLVMBuildOr, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildStore, LLVMCreateBuilderInContext,
-    LLVMDisposeBuilder, LLVMGetParam, LLVMPositionBuilderAtEnd, UNNAMED,
+    LLVMBuildOr, LLVMBuildRet, LLVMBuildStore, LLVMCreateBuilderInContext, LLVMDisposeBuilder,
+    LLVMGetParam, LLVMPositionBuilderAtEnd, UNNAMED,
 };
 use mir_llvm::{Builder, BuilderVal, CallbackFun, MemLoc};
 use sim_back::{BoundStepKind, SimUnknown};
@@ -27,11 +27,9 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
         let name = &format!("eval_{}", &self.module.sym);
         let cx = &self.cx;
 
-        let ty_void_ptr = cx.ty_void_ptr();
-        let siminfo_ptr_ty = cx.ptr_ty(self.tys.osdi_sim_info);
+        let ty_ptr = cx.ty_ptr();
 
-        let fun_ty =
-            cx.ty_func(&[ty_void_ptr, ty_void_ptr, ty_void_ptr, siminfo_ptr_ty], cx.ty_int());
+        let fun_ty = cx.ty_func(&[ty_ptr, ty_ptr, ty_ptr, ty_ptr], cx.ty_int());
         cx.declare_ext_fn(name, fun_ty)
     }
 
@@ -47,36 +45,29 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
         let postorder: Vec<_> = cfg.postorder(func).collect();
 
         let handle = unsafe { llvm::LLVMGetParam(llfunc, 0) };
-        let instance = unsafe {
-            let raw = llvm::LLVMGetParam(llfunc, 1);
-            builder.ptrcast(raw, cx.ptr_ty(inst_data.ty))
-        };
-        let model = unsafe {
-            let raw = llvm::LLVMGetParam(llfunc, 2);
-            builder.ptrcast(raw, cx.ptr_ty(model_data.ty))
-        };
+        let instance = unsafe { llvm::LLVMGetParam(llfunc, 1) };
+        let model = unsafe { llvm::LLVMGetParam(llfunc, 2) };
         let sim_info = unsafe { llvm::LLVMGetParam(llfunc, 3) };
-        let sim_info_void = unsafe { builder.ptrcast(sim_info, cx.ty_void_ptr()) };
         let sim_info_ty = self.tys.osdi_sim_info;
 
         // let simparam_ty = self.tys.osdi_sim_paras;
-        let simparam = unsafe { builder.typed_struct_gep(sim_info_ty, sim_info, 0) };
+        let simparam = unsafe { builder.struct_gep(sim_info_ty, sim_info, 0) };
 
         const ABSTIME_OFFSET: u32 = 1;
 
         let prev_result = unsafe {
-            let ptr = builder.typed_struct_gep(sim_info_ty, sim_info, 2);
-            builder.load(cx.ptr_ty(cx.ty_real()), ptr)
+            let ptr = builder.struct_gep(sim_info_ty, sim_info, 2);
+            builder.load(cx.ty_ptr(), ptr)
         };
 
         let prev_state = unsafe {
-            let ptr = builder.typed_struct_gep(sim_info_ty, sim_info, 3);
-            builder.load(cx.ptr_ty(cx.ty_real()), ptr)
+            let ptr = builder.struct_gep(sim_info_ty, sim_info, 3);
+            builder.load(cx.ty_ptr(), ptr)
         };
 
         let next_state = unsafe {
-            let ptr = builder.typed_struct_gep(sim_info_ty, sim_info, 3);
-            builder.load(cx.ptr_ty(cx.ty_real()), ptr)
+            let ptr = builder.struct_gep(sim_info_ty, sim_info, 3);
+            builder.load(cx.ty_ptr(), ptr)
         };
 
         let flags = MemLoc::struct_gep(sim_info, sim_info_ty, cx.ty_int(), 5, cx);
@@ -137,7 +128,7 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
                             let loc = MemLoc::struct_gep(
                                 sim_info,
                                 sim_info_ty,
-                                cx.ty_real(),
+                                cx.ty_double(),
                                 ABSTIME_OFFSET,
                                 cx,
                             );
@@ -202,8 +193,8 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
                                 inst_data.read_state_idx(cx, state, instance, builder.llbuilder);
                             return MemLoc {
                                 ptr: prev_state,
-                                ptr_ty: cx.ty_real(),
-                                ty: cx.ty_real(),
+                                ptr_ty: cx.ty_double(),
+                                ty: cx.ty_double(),
                                 indicies: vec![idx].into_boxed_slice(),
                             }
                             .into();
@@ -214,8 +205,8 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
 
                             return MemLoc {
                                 ptr: next_state,
-                                ptr_ty: cx.ty_real(),
-                                ty: cx.ty_real(),
+                                ptr_ty: cx.ty_double(),
+                                ty: cx.ty_double(),
                                 indicies: vec![idx].into_boxed_slice(),
                             }
                             .into();
@@ -240,7 +231,7 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
 
         builder.callbacks = general_callbacks(intern, &mut builder, ret_flags, handle, simparam);
 
-        let ty_real_ptr = cx.ptr_ty(cx.ty_real());
+        let ty_real_ptr = cx.ty_ptr();
         if module.mir.bound_step == BoundStepKind::Eval {
             let bound_step_ptr = unsafe { inst_data.bound_step_ptr(&builder, instance) };
             unsafe { builder.store(bound_step_ptr, cx.const_real(f64::INFINITY)) };
@@ -250,7 +241,7 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
                 .cx
                 .get_func_by_name("bound_step")
                 .expect("stdlib function bound_step is missing");
-            let fun_ty = cx.ty_func(&[ty_real_ptr, cx.ty_real()], cx.ty_void());
+            let fun_ty = cx.ty_func(&[ty_real_ptr, cx.ty_double()], cx.ty_void());
             let cb = CallbackFun { fun_ty, fun, state: Box::new([bound_step_ptr]), num_state: 0 };
             builder.callbacks[func_ref] = Some(cb);
         }
@@ -259,8 +250,7 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
             .cx
             .get_func_by_name("store_delay")
             .expect("stdlib function store_delay is missing");
-        let store_delay_ty =
-            cx.ty_func(&[cx.ty_void_ptr(), ty_real_ptr, cx.ty_real()], cx.ty_void());
+        let store_delay_ty = cx.ty_func(&[cx.ty_ptr(), ty_real_ptr, cx.ty_double()], cx.ty_void());
 
         for (func, kind) in intern.callbacks.iter_enumerated() {
             let cb = match *kind {
@@ -276,11 +266,11 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
                         .get_func_by_name("store_lim")
                         .expect("stdlib function store_lim is missing");
                     let fun_ty =
-                        cx.ty_func(&[cx.ty_void_ptr(), cx.ty_int(), cx.ty_real()], cx.ty_real());
+                        cx.ty_func(&[cx.ty_ptr(), cx.ty_int(), cx.ty_double()], cx.ty_double());
                     CallbackFun {
                         fun_ty,
                         fun,
-                        state: Box::new([sim_info_void, state_idx[state]]),
+                        state: Box::new([sim_info, state_idx[state]]),
                         num_state: 0,
                     }
                 }
@@ -289,7 +279,7 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
                         .cx
                         .get_func_by_name("lim_discontinuity")
                         .expect("stdlib function lim_discontinuity is missing");
-                    let fun_ty = cx.ty_func(&[cx.ptr_ty(cx.ty_int())], cx.ty_void());
+                    let fun_ty = cx.ty_func(&[cx.ty_ptr()], cx.ty_void());
                     CallbackFun { fun_ty, fun, state: Box::new([ret_flags]), num_state: 0 }
                 }
                 CallBackKind::Analysis => {
@@ -297,8 +287,8 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
                         .cx
                         .get_func_by_name("analysis")
                         .expect("stdlib function analysis is missing");
-                    let fun_ty = cx.ty_func(&[cx.ty_void_ptr(), cx.ty_str()], cx.ty_int());
-                    CallbackFun { fun_ty, fun, state: Box::new([sim_info_void]), num_state: 0 }
+                    let fun_ty = cx.ty_func(&[cx.ty_ptr(), cx.ty_ptr()], cx.ty_int());
+                    CallbackFun { fun_ty, fun, state: Box::new([sim_info]), num_state: 0 }
                 }
                 CallBackKind::StoreDelayTime(eq) => {
                     let slot = if let Some(&slot) = self.module.mir.eval_cache_vals.get(&eq) {
@@ -310,7 +300,7 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
                     CallbackFun {
                         fun_ty: store_delay_ty,
                         fun: store_delay_fun,
-                        state: Box::new([sim_info_void, slot]),
+                        state: Box::new([sim_info, slot]),
                         num_state: 0,
                     }
                 }
@@ -449,11 +439,11 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
         let OsdiCompilationUnit { cx, tys, .. } = self;
         let table = self.lim_dispatch_table();
 
-        let double = cx.ty_real();
+        let double = cx.ty_double();
         let c_bool = cx.ty_c_bool();
         let int = cx.ty_int();
 
-        let mut args = vec![cx.ptr_ty(flags_loc.ptr_ty), cx.ptr_ty(int), double, double];
+        let mut args = vec![cx.ty_ptr(), cx.ty_ptr(), double, double];
         args.resize(num_args as usize + 4, double);
         let fun_ty = cx.ty_func(&args, double);
         let name = &format!("lim_{}_{id}", &self.module.sym);
@@ -483,12 +473,10 @@ impl<'ll> OsdiCompilationUnit<'_, '_, 'll> {
                 UNNAMED,
             );
 
-            let mut func_ptr = LLVMBuildLoad2(llbuilder, cx.ty_void_ptr(), func_ptr_ptr, UNNAMED);
-            let mut lim_fn_args = vec![c_bool, cx.ptr_ty(c_bool), double, double];
+            let func_ptr = LLVMBuildLoad2(llbuilder, cx.ty_ptr(), func_ptr_ptr, UNNAMED);
+            let mut lim_fn_args = vec![c_bool, cx.ty_ptr(), double, double];
             lim_fn_args.extend((0..num_args).map(|_| double));
             let lim_fn_ty = cx.ty_func(&lim_fn_args, double);
-            func_ptr = LLVMBuildPointerCast(llbuilder, func_ptr, cx.ptr_ty(lim_fn_ty), UNNAMED);
-
             let mut args = vec![init, val_changed];
             args.extend((2..4 + num_args).map(|i| LLVMGetParam(llfunc, i)));
             let res = LLVMBuildCall2(

--- a/openvaf/osdi/src/lib.rs
+++ b/openvaf/osdi/src/lib.rs
@@ -205,8 +205,7 @@ pub fn compile(
 
         let osdi_log =
             cx.get_declared_value("osdi_log").expect("symbol osdi_log mising from std lib");
-        let fun_ty = cx.ty_func(&[cx.ty_void_ptr(), cx.ty_str(), cx.ty_int()], cx.ty_void());
-        let val = cx.const_null_ptr(cx.ptr_ty(fun_ty));
+        let val = cx.const_null_ptr();
         unsafe {
             llvm::LLVMSetInitializer(osdi_log, val);
             llvm::LLVMSetLinkage(osdi_log, llvm::Linkage::ExternalLinkage);
@@ -293,9 +292,9 @@ fn ty_len(ty: &Type) -> Option<u32> {
 
 fn lltype<'ll>(ty: &Type, cx: &CodegenCx<'_, 'll>) -> &'ll llvm::Type {
     let llty = match ty.base_type() {
-        Type::Real => cx.ty_real(),
+        Type::Real => cx.ty_double(),
         Type::Integer => cx.ty_int(),
-        Type::String => cx.ty_str(),
+        Type::String => cx.ty_ptr(),
         Type::EmptyArray => cx.ty_array(cx.ty_int(), 0),
         Type::Bool => cx.ty_c_bool(),
         Type::Void => cx.ty_void(),

--- a/openvaf/osdi/src/metadata.rs
+++ b/openvaf/osdi/src/metadata.rs
@@ -38,7 +38,7 @@ impl OsdiLimFunction {
         osdi_0_3::OsdiLimFunction {
             name: ctx.literals.resolve(&self.name).to_owned(),
             num_args: self.num_args,
-            func_ptr: ctx.const_null_ptr(ctx.ty_void_ptr()),
+            func_ptr: ctx.const_null_ptr(),
         }
         .to_ll_val(ctx, tys)
     }

--- a/openvaf/osdi/src/metadata/osdi_0_3.rs
+++ b/openvaf/osdi/src/metadata/osdi_0_3.rs
@@ -92,21 +92,16 @@ impl<'ll> OsdiLimFunction<'ll> {
 impl OsdiTyBuilder<'_, '_, '_> {
     fn osdi_lim_function(&mut self) {
         let ctx = self.ctx;
-        let fields = [ctx.ty_str(), ctx.ty_int(), ctx.ty_void_ptr()];
-        let ty = ctx.struct_ty("OsdiLimFunction", &fields);
+        let fields = [ctx.ty_ptr(), ctx.ty_int(), ctx.ty_ptr()];
+        let ty = ctx.ty_struct("OsdiLimFunction", &fields);
         self.osdi_lim_function = Some(ty);
     }
 }
 impl OsdiTyBuilder<'_, '_, '_> {
     fn osdi_sim_paras(&mut self) {
         let ctx = self.ctx;
-        let fields = [
-            ctx.ptr_ty(ctx.ty_str()),
-            ctx.ptr_ty(ctx.ty_real()),
-            ctx.ptr_ty(ctx.ty_str()),
-            ctx.ptr_ty(ctx.ty_str()),
-        ];
-        let ty = ctx.struct_ty("OsdiSimParas", &fields);
+        let fields = [ctx.ty_ptr(), ctx.ty_ptr(), ctx.ty_ptr(), ctx.ty_ptr()];
+        let ty = ctx.ty_struct("OsdiSimParas", &fields);
         self.osdi_sim_paras = Some(ty);
     }
 }
@@ -115,13 +110,13 @@ impl OsdiTyBuilder<'_, '_, '_> {
         let ctx = self.ctx;
         let fields = [
             self.osdi_sim_paras.unwrap(),
-            ctx.ty_real(),
-            ctx.ptr_ty(ctx.ty_real()),
-            ctx.ptr_ty(ctx.ty_real()),
-            ctx.ptr_ty(ctx.ty_real()),
+            ctx.ty_double(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
             ctx.ty_int(),
         ];
-        let ty = ctx.struct_ty("OsdiSimInfo", &fields);
+        let ty = ctx.ty_struct("OsdiSimInfo", &fields);
         self.osdi_sim_info = Some(ty);
     }
 }
@@ -148,15 +143,15 @@ impl OsdiTyBuilder<'_, '_, '_> {
     fn osdi_init_error(&mut self) {
         let ctx = self.ctx;
         let fields = [ctx.ty_int(), self.osdi_init_error_payload.unwrap()];
-        let ty = ctx.struct_ty("OsdiInitError", &fields);
+        let ty = ctx.ty_struct("OsdiInitError", &fields);
         self.osdi_init_error = Some(ty);
     }
 }
 impl OsdiTyBuilder<'_, '_, '_> {
     fn osdi_init_info(&mut self) {
         let ctx = self.ctx;
-        let fields = [ctx.ty_int(), ctx.ty_int(), ctx.ptr_ty(self.osdi_init_error.unwrap())];
-        let ty = ctx.struct_ty("OsdiInitInfo", &fields);
+        let fields = [ctx.ty_int(), ctx.ty_int(), ctx.ty_ptr()];
+        let ty = ctx.ty_struct("OsdiInitInfo", &fields);
         self.osdi_init_info = Some(ty);
     }
 }
@@ -175,7 +170,7 @@ impl OsdiTyBuilder<'_, '_, '_> {
     fn osdi_node_pair(&mut self) {
         let ctx = self.ctx;
         let fields = [ctx.ty_int(), ctx.ty_int()];
-        let ty = ctx.struct_ty("OsdiNodePair", &fields);
+        let ty = ctx.ty_struct("OsdiNodePair", &fields);
         self.osdi_node_pair = Some(ty);
     }
 }
@@ -199,7 +194,7 @@ impl OsdiTyBuilder<'_, '_, '_> {
     fn osdi_jacobian_entry(&mut self) {
         let ctx = self.ctx;
         let fields = [self.osdi_node_pair.unwrap(), ctx.ty_int(), ctx.ty_int()];
-        let ty = ctx.struct_ty("OsdiJacobianEntry", &fields);
+        let ty = ctx.ty_struct("OsdiJacobianEntry", &fields);
         self.osdi_jacobian_entry = Some(ty);
     }
 }
@@ -233,16 +228,16 @@ impl OsdiTyBuilder<'_, '_, '_> {
     fn osdi_node(&mut self) {
         let ctx = self.ctx;
         let fields = [
-            ctx.ty_str(),
-            ctx.ty_str(),
-            ctx.ty_str(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
             ctx.ty_int(),
             ctx.ty_int(),
             ctx.ty_int(),
             ctx.ty_int(),
             ctx.ty_c_bool(),
         ];
-        let ty = ctx.struct_ty("OsdiNode", &fields);
+        let ty = ctx.ty_struct("OsdiNode", &fields);
         self.osdi_node = Some(ty);
     }
 }
@@ -258,7 +253,7 @@ impl OsdiParamOpvar {
     pub fn to_ll_val<'ll>(&self, ctx: &CodegenCx<'_, 'll>, tys: &'ll OsdiTys) -> &'ll llvm::Value {
         let arr_0: Vec<_> = self.name.iter().map(|it| ctx.const_str_uninterned(it)).collect();
         let fields = [
-            ctx.const_arr_ptr(ctx.ty_str(), &arr_0),
+            ctx.const_arr_ptr(ctx.ty_ptr(), &arr_0),
             ctx.const_unsigned_int(self.num_alias),
             ctx.const_str_uninterned(&self.description),
             ctx.const_str_uninterned(&self.units),
@@ -272,15 +267,9 @@ impl OsdiParamOpvar {
 impl OsdiTyBuilder<'_, '_, '_> {
     fn osdi_param_opvar(&mut self) {
         let ctx = self.ctx;
-        let fields = [
-            ctx.ptr_ty(ctx.ty_str()),
-            ctx.ty_int(),
-            ctx.ty_str(),
-            ctx.ty_str(),
-            ctx.ty_int(),
-            ctx.ty_int(),
-        ];
-        let ty = ctx.struct_ty("OsdiParamOpvar", &fields);
+        let fields =
+            [ctx.ty_ptr(), ctx.ty_int(), ctx.ty_ptr(), ctx.ty_ptr(), ctx.ty_int(), ctx.ty_int()];
+        let ty = ctx.ty_struct("OsdiParamOpvar", &fields);
         self.osdi_param_opvar = Some(ty);
     }
 }
@@ -298,8 +287,8 @@ impl OsdiNoiseSource {
 impl OsdiTyBuilder<'_, '_, '_> {
     fn osdi_noise_source(&mut self) {
         let ctx = self.ctx;
-        let fields = [ctx.ty_str(), self.osdi_node_pair.unwrap()];
-        let ty = ctx.struct_ty("OsdiNoiseSource", &fields);
+        let fields = [ctx.ty_ptr(), self.osdi_node_pair.unwrap()];
+        let ty = ctx.ty_struct("OsdiNoiseSource", &fields);
         self.osdi_noise_source = Some(ty);
     }
 }
@@ -394,116 +383,44 @@ impl OsdiTyBuilder<'_, '_, '_> {
     fn osdi_descriptor(&mut self) {
         let ctx = self.ctx;
         let fields = [
-            ctx.ty_str(),
+            ctx.ty_ptr(),
             ctx.ty_int(),
             ctx.ty_int(),
-            ctx.ptr_ty(self.osdi_node.unwrap()),
+            ctx.ty_ptr(),
             ctx.ty_int(),
-            ctx.ptr_ty(self.osdi_jacobian_entry.unwrap()),
+            ctx.ty_ptr(),
             ctx.ty_int(),
-            ctx.ptr_ty(self.osdi_node_pair.unwrap()),
+            ctx.ty_ptr(),
             ctx.ty_int(),
-            ctx.ptr_ty(self.osdi_noise_source.unwrap()),
-            ctx.ty_int(),
-            ctx.ty_int(),
-            ctx.ty_int(),
-            ctx.ty_int(),
-            ctx.ptr_ty(self.osdi_param_opvar.unwrap()),
+            ctx.ty_ptr(),
             ctx.ty_int(),
             ctx.ty_int(),
             ctx.ty_int(),
             ctx.ty_int(),
+            ctx.ty_ptr(),
             ctx.ty_int(),
             ctx.ty_int(),
             ctx.ty_int(),
-            ctx.ptr_ty(ctx.ty_func(
-                &[ctx.ty_void_ptr(), ctx.ty_void_ptr(), ctx.ty_int(), ctx.ty_int()],
-                ctx.ty_void_ptr(),
-            )),
-            ctx.ptr_ty(ctx.ty_func(
-                &[
-                    ctx.ty_void_ptr(),
-                    ctx.ty_void_ptr(),
-                    ctx.ptr_ty(self.osdi_sim_paras.unwrap()),
-                    ctx.ptr_ty(self.osdi_init_info.unwrap()),
-                ],
-                ctx.ty_void(),
-            )),
-            ctx.ptr_ty(ctx.ty_func(
-                &[
-                    ctx.ty_void_ptr(),
-                    ctx.ty_void_ptr(),
-                    ctx.ty_void_ptr(),
-                    ctx.ty_real(),
-                    ctx.ty_int(),
-                    ctx.ptr_ty(self.osdi_sim_paras.unwrap()),
-                    ctx.ptr_ty(self.osdi_init_info.unwrap()),
-                ],
-                ctx.ty_void(),
-            )),
-            ctx.ptr_ty(ctx.ty_func(
-                &[
-                    ctx.ty_void_ptr(),
-                    ctx.ty_void_ptr(),
-                    ctx.ty_void_ptr(),
-                    ctx.ptr_ty(self.osdi_sim_info.unwrap()),
-                ],
-                ctx.ty_int(),
-            )),
-            ctx.ptr_ty(ctx.ty_func(
-                &[
-                    ctx.ty_void_ptr(),
-                    ctx.ty_void_ptr(),
-                    ctx.ty_real(),
-                    ctx.ptr_ty(ctx.ty_real()),
-                    ctx.ptr_ty(ctx.ty_real()),
-                ],
-                ctx.ty_void(),
-            )),
-            ctx.ptr_ty(ctx.ty_func(
-                &[ctx.ty_void_ptr(), ctx.ty_void_ptr(), ctx.ptr_ty(ctx.ty_real())],
-                ctx.ty_void(),
-            )),
-            ctx.ptr_ty(ctx.ty_func(
-                &[ctx.ty_void_ptr(), ctx.ty_void_ptr(), ctx.ptr_ty(ctx.ty_real())],
-                ctx.ty_void(),
-            )),
-            ctx.ptr_ty(ctx.ty_func(
-                &[ctx.ty_void_ptr(), ctx.ty_void_ptr(), ctx.ptr_ty(ctx.ty_real())],
-                ctx.ty_void(),
-            )),
-            ctx.ptr_ty(ctx.ty_func(
-                &[ctx.ty_void_ptr(), ctx.ty_void_ptr(), ctx.ptr_ty(ctx.ty_real())],
-                ctx.ty_void(),
-            )),
-            ctx.ptr_ty(ctx.ty_func(
-                &[
-                    ctx.ty_void_ptr(),
-                    ctx.ty_void_ptr(),
-                    ctx.ptr_ty(ctx.ty_real()),
-                    ctx.ptr_ty(ctx.ty_real()),
-                ],
-                ctx.ty_void(),
-            )),
-            ctx.ptr_ty(ctx.ty_func(
-                &[
-                    ctx.ty_void_ptr(),
-                    ctx.ty_void_ptr(),
-                    ctx.ptr_ty(ctx.ty_real()),
-                    ctx.ptr_ty(ctx.ty_real()),
-                    ctx.ty_real(),
-                ],
-                ctx.ty_void(),
-            )),
-            ctx.ptr_ty(ctx.ty_func(&[ctx.ty_void_ptr(), ctx.ty_void_ptr()], ctx.ty_void())),
-            ctx.ptr_ty(
-                ctx.ty_func(&[ctx.ty_void_ptr(), ctx.ty_void_ptr(), ctx.ty_real()], ctx.ty_void()),
-            ),
-            ctx.ptr_ty(
-                ctx.ty_func(&[ctx.ty_void_ptr(), ctx.ty_void_ptr(), ctx.ty_real()], ctx.ty_void()),
-            ),
+            ctx.ty_int(),
+            ctx.ty_int(),
+            ctx.ty_int(),
+            ctx.ty_int(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
+            ctx.ty_ptr(),
         ];
-        let ty = ctx.struct_ty("OsdiDescriptor", &fields);
+        let ty = ctx.ty_struct("OsdiDescriptor", &fields);
         self.osdi_descriptor = Some(ty);
     }
 }

--- a/openvaf/osdi/src/model_data.rs
+++ b/openvaf/osdi/src/model_data.rs
@@ -44,7 +44,7 @@ impl<'ll> OsdiModelData<'ll> {
 
         let name = &cgunit.sym;
         let name = format!("osdi_model_data_{name}");
-        let ty = cx.struct_ty(&name, &fields);
+        let ty = cx.ty_struct(&name, &fields);
 
         OsdiModelData { param_given, params, ty }
     }

--- a/openvaf/preprocessor/Cargo.toml
+++ b/openvaf/preprocessor/Cargo.toml
@@ -25,7 +25,7 @@ tokens = {version="0.0.0", path="../tokens"}
 
 
 [dev-dependencies]
-expect-test = "1.4.0"
+expect-test = "1.4.1"
 
 
 # data-structures = {version = "0.0.0", path = "../data_structures" }

--- a/openvaf/sim_back/Cargo.toml
+++ b/openvaf/sim_back/Cargo.toml
@@ -28,14 +28,14 @@ workqueue = {version = "0.0.0", path = "../../lib/workqueue" }
 
 typed-index-collections = "3.1"
 ahash = "0.8"
-lasso = {version = "0.6", features = ["ahash"]}
+lasso = {version = "0.7", features = ["ahash"]}
 parking_lot = "0.12"
 
 anyhow = "1"
 
 salsa = "0.17.0-pre.2"
 indexmap = "1.9"
-smol_str = {version = "0.1.23", default_features=false}
+smol_str = {version = "0.2", default_features=false}
 
 
 

--- a/openvaf/syntax/Cargo.toml
+++ b/openvaf/syntax/Cargo.toml
@@ -25,4 +25,4 @@ tokens = {version="0.0.0", path="../tokens"}
 text-size = "1.1"
 
 rowan = "0.15"
-smol_str = {version = "0.1.23", default_features=false}
+smol_str = {version = "0.2", default_features=false}

--- a/openvaf/test_data/ui/ddx.log
+++ b/openvaf/test_data/ui/ddx.log
@@ -1,7 +1,7 @@
 warning[L011]: unkown supplied to the ddx operator is not standard compilant
-   ┌─ /ddx.va:15:21
+   ┌─ /ddx.va:16:21
    │
-15 │         x = ddx(1.0,V(a,c));
+16 │         x = ddx(1.0,V(a,c));
    │                     ^^^^^^ unkown is not standard compliant
    │
    = note: this functionality is fully suported by openvaf
@@ -13,22 +13,10 @@ warning[L011]: unkown supplied to the ddx operator is not standard compilant
      use a CLI argument or an attribute to overwrite
 
 error: invalid unkown was supplied to the ddx operator
-   ┌─ /ddx.va:19:21
-   │
-19 │         x = ddx(1.0,V(br_ac));
-   │                     ^^^^^^^^ invalid ddx unkown
-   │
-   = help: expected one of the following
-     branch current acces: I(branch), I(a,b)
-     node voltage: V(x)
-     explicit voltage: V(x,y)
-     temperature: $temperature
-
-error: invalid unkown was supplied to the ddx operator
    ┌─ /ddx.va:20:21
    │
-20 │         x = ddx(1.0,I(a,c));
-   │                     ^^^^^^ invalid ddx unkown
+20 │         x = ddx(1.0,V(br_ac));
+   │                     ^^^^^^^^ invalid ddx unkown
    │
    = help: expected one of the following
      branch current acces: I(branch), I(a,b)
@@ -39,8 +27,8 @@ error: invalid unkown was supplied to the ddx operator
 error: invalid unkown was supplied to the ddx operator
    ┌─ /ddx.va:21:21
    │
-21 │         x = ddx(1.0,I(a));
-   │                     ^^^^ invalid ddx unkown
+21 │         x = ddx(1.0,I(a,c));
+   │                     ^^^^^^ invalid ddx unkown
    │
    = help: expected one of the following
      branch current acces: I(branch), I(a,b)
@@ -51,8 +39,8 @@ error: invalid unkown was supplied to the ddx operator
 error: invalid unkown was supplied to the ddx operator
    ┌─ /ddx.va:22:21
    │
-22 │         x = ddx(1.0,I(<a>));
-   │                     ^^^^^^ invalid ddx unkown
+22 │         x = ddx(1.0,I(a));
+   │                     ^^^^ invalid ddx unkown
    │
    = help: expected one of the following
      branch current acces: I(branch), I(a,b)
@@ -63,7 +51,19 @@ error: invalid unkown was supplied to the ddx operator
 error: invalid unkown was supplied to the ddx operator
    ┌─ /ddx.va:23:21
    │
-23 │         x = ddx(1.0,V(<a>));
+23 │         x = ddx(1.0,I(<a>));
+   │                     ^^^^^^ invalid ddx unkown
+   │
+   = help: expected one of the following
+     branch current acces: I(branch), I(a,b)
+     node voltage: V(x)
+     explicit voltage: V(x,y)
+     temperature: $temperature
+
+error: invalid unkown was supplied to the ddx operator
+   ┌─ /ddx.va:24:21
+   │
+24 │         x = ddx(1.0,V(<a>));
    │                     ^^^^^^ invalid ddx unkown
    │
    = help: expected one of the following
@@ -73,9 +73,9 @@ error: invalid unkown was supplied to the ddx operator
      temperature: $temperature
 
 error: access of port-branch potential
-   ┌─ /ddx.va:23:21
+   ┌─ /ddx.va:24:21
    │
-23 │         x = ddx(1.0,V(<a>));
+24 │         x = ddx(1.0,V(<a>));
    │                     ^^^^^^ invalid potential access
    │
    = help: only the flow of port branches like <foo> can be accessed

--- a/openvaf/test_data/ui/ddx.va
+++ b/openvaf/test_data/ui/ddx.va
@@ -1,4 +1,5 @@
 `include "disciplines.va"
+(* openvaf_allow="trivial_probe" *)
 module diode(a, c);
     real x;
     inout c;

--- a/verilogae/verilogae/Cargo.toml
+++ b/verilogae/verilogae/Cargo.toml
@@ -33,15 +33,15 @@ bitset = { version = "0.0.0", path = "../../lib/bitset" }
 base_n = { version = "1", path = "../../lib/base_n" }
 paths = { version = "0.0", path = "../../lib/paths" }
 
-lasso = { version = "0.6", features = ["ahash"] }
+lasso = { version = "0.7", features = ["ahash"] }
 indexmap = "1.9"
 md5 = "0.7"
 directories-next = "2"
-libloading = "0.7"
+libloading = "0.8"
 
 rayon-core = "1"
 
-smol_str = { version = "0.1.23", default_features = false }
+smol_str = { version = "0.2", default_features = false }
 parking_lot = "0.12"
 typed-index-collections = "3"
 ahash = "0.8"
@@ -50,4 +50,4 @@ anyhow = "1"
 termcolor = "1.2"
 
 salsa = "0.17.0-pre.2"
-camino = "1.1.2"
+camino = "1.1.4"

--- a/verilogae/verilogae/src/back.rs
+++ b/verilogae/verilogae/src/back.rs
@@ -16,25 +16,25 @@ use typed_indexmap::TiSet;
 use crate::compiler_db::{CompilationDB, FuncSpec, InternedModel, ModelInfo};
 
 pub fn sim_param_stub<'ll>(cx: &CodegenCx<'_, 'll>) -> CallbackFun<'ll> {
-    cx.const_callback(&[cx.ty_str()], cx.const_real(0.0))
+    cx.const_callback(&[cx.ty_ptr()], cx.const_real(0.0))
 }
 
 pub fn sim_param_opt_stub<'ll>(cx: &CodegenCx<'_, 'll>) -> CallbackFun<'ll> {
-    cx.const_return(&[cx.ty_str(), cx.ty_real()], 1)
+    cx.const_return(&[cx.ty_ptr(), cx.ty_double()], 1)
 }
 
 pub fn sim_param_str_stub<'ll>(cx: &CodegenCx<'_, 'll>) -> CallbackFun<'ll> {
     let empty_str = cx.literals.get("").unwrap();
     let empty_str = cx.const_str(empty_str);
-    let ty_str = cx.ty_str();
+    let ty_str = cx.ty_ptr();
     cx.const_callback(&[ty_str], empty_str)
 }
 
 pub fn lltype<'ll>(ty: &Type, cx: &CodegenCx<'_, 'll>) -> &'ll llvm::Type {
     match ty {
-        Type::Real => cx.ty_real(),
+        Type::Real => cx.ty_double(),
         Type::Integer => cx.ty_int(),
-        Type::String => cx.ty_str(),
+        Type::String => cx.ty_ptr(),
         Type::Array { ty, len } => cx.ty_array(lltype(ty, cx), *len),
         Type::EmptyArray => cx.ty_array(cx.ty_int(), 0),
         Type::Bool => cx.ty_bool(),
@@ -56,7 +56,7 @@ pub fn stub_callbacks<'ll>(
                 CallBackKind::SimParamOpt => sim_param_opt_stub(cx),
                 CallBackKind::SimParamStr => sim_param_str_stub(cx),
                 CallBackKind::Derivative(_) | CallBackKind::NodeDerivative(_) => {
-                    cx.const_callback(&[cx.ty_real()], cx.const_real(0.0))
+                    cx.const_callback(&[cx.ty_double()], cx.const_real(0.0))
                 }
                 CallBackKind::Print { .. }
                 | CallBackKind::BoundStep
@@ -66,7 +66,7 @@ pub fn stub_callbacks<'ll>(
                 | CallBackKind::LimDiscontinuity
                 | CallBackKind::StoreDelayTime(_)
                 | CallBackKind::CollapseHint(_, _) => return None,
-                CallBackKind::Analysis => cx.const_callback(&[cx.ty_str()], cx.const_int(1)),
+                CallBackKind::Analysis => cx.const_callback(&[cx.ty_ptr()], cx.const_int(1)),
             };
 
             Some(res)
@@ -98,10 +98,10 @@ impl<'ll> Codegen<'_, '_, 'll> {
             .iter()
             .copied()
             .filter(|var| self.db.var_data(*var).ty == ty);
-
+        let llty = lltype(&ty, self.builder.cx);
         for (i, var) in vars.clone().enumerate() {
             if let Some(id) = self.intern.params.index(&ParamKind::HiddenState(var)) {
-                self.builder.params[id] = self.read_fat_ptr_at(i, offset, ptr).into();
+                self.builder.params[id] = self.read_fat_ptr_at(i, offset, ptr, llty).into();
             }
         }
 
@@ -120,8 +120,12 @@ impl<'ll> Codegen<'_, '_, 'll> {
         });
 
         for (i, (id, _)) in params.clone().enumerate() {
-            let ptr = self.builder.cx.const_gep(ptr, &[self.builder.cx.const_usize(i)]);
-            self.builder.params[id] = self.builder.load(self.builder.cx.ty_str(), ptr).into();
+            let ptr = self.builder.cx.const_gep(
+                self.builder.cx.ty_ptr(),
+                ptr,
+                &[self.builder.cx.const_usize(i)],
+            );
+            self.builder.params[id] = self.builder.load(self.builder.cx.ty_ptr(), ptr).into();
         }
 
         let global_name = format!("{}.params.{}", self.spec.prefix, Type::String);
@@ -138,8 +142,9 @@ impl<'ll> Codegen<'_, '_, 'll> {
             }
         });
 
+        let llty = lltype(&ty, self.builder.cx);
         for (i, (id, _)) in params.clone().enumerate() {
-            self.builder.params[id] = self.read_fat_ptr_at(i, offset, ptr).into();
+            self.builder.params[id] = self.read_fat_ptr_at(i, offset, ptr, llty).into();
         }
 
         let global_name = format!("{}.params.{}", self.spec.prefix, ty);
@@ -172,13 +177,14 @@ impl<'ll> Codegen<'_, '_, 'll> {
         let voltages = optional_voltages.into_iter().chain(non_optional_voltages);
 
         for (i, (id, _)) in voltages.clone().enumerate() {
-            self.builder.params[id] = self.read_fat_ptr_at(i, offset, ptr).into();
+            self.builder.params[id] =
+                self.read_fat_ptr_at(i, offset, ptr, self.builder.cx.ty_double()).into();
         }
 
         let global_name = format!("{}.voltages.default", self.spec.prefix);
         self.builder.cx.export_array(
             &global_name,
-            self.builder.cx.ty_real(),
+            self.builder.cx.ty_double(),
             &default_vals,
             true,
             true,
@@ -216,13 +222,14 @@ impl<'ll> Codegen<'_, '_, 'll> {
         let voltages = optional_voltages.into_iter().chain(non_optional_voltages);
 
         for (i, (id, _)) in voltages.clone().enumerate() {
-            self.builder.params[id] = self.read_fat_ptr_at(i, offset, ptr).into();
+            self.builder.params[id] =
+                self.read_fat_ptr_at(i, offset, ptr, self.builder.cx.ty_double()).into();
         }
 
         let global_name = format!("{}.currents.default", self.spec.prefix);
         self.builder.cx.export_array(
             &global_name,
-            self.builder.cx.ty_real(),
+            self.builder.cx.ty_double(),
             &default_vals,
             true,
             true,
@@ -242,7 +249,7 @@ impl<'ll> Codegen<'_, '_, 'll> {
                 cx.const_str(name)
             })
             .collect();
-        cx.export_array(global_name, cx.ty_str(), &names, true, true);
+        cx.export_array(global_name, cx.ty_ptr(), &names, true, true);
     }
 
     unsafe fn read_fat_ptr_at(
@@ -250,33 +257,31 @@ impl<'ll> Codegen<'_, '_, 'll> {
         pos: usize,
         offset: &'ll llvm::Value,
         ptr: &'ll llvm::Value,
+        ptr_ty: &'ll llvm::Type,
     ) -> &'ll llvm::Value {
         let builder = &mut self.builder;
 
         // get correct ptrs from array
-        let fat_ptr = builder.gep(ptr, &[builder.cx.const_usize(pos)]);
+        let fat_ptr = builder.gep(builder.cx.ty_fat_ptr(), ptr, &[builder.cx.const_usize(pos)]);
 
         let (ptr, meta) = builder.fat_ptr_to_parts(fat_ptr);
-        let ptr_ty = builder.cx.elem_ty(builder.cx.val_ty(ptr));
 
         // get stride or scalar ptr by bitcasting
-        let stride_ptr = builder.ptrcast(meta, builder.cx.ptr_ty(builder.cx.ty_isize()));
-        let stride = builder.load(builder.cx.ty_isize(), stride_ptr);
-        let scalar_ptr = builder.ptrcast(meta, ptr_ty);
+        let stride = builder.load(builder.cx.ty_size(), meta);
 
         // load the array ptr and check if its a null ptr
-        let arr_ptr = builder.load(ptr_ty, ptr);
+        let arr_ptr = builder.load(builder.cx.ty_ptr(), ptr);
         let is_arr_null = builder.is_null_ptr(arr_ptr);
 
         // offset the array _ptr
         let offset = builder.imul(stride, offset);
-        let arr_ptr = builder.gep(arr_ptr, &[offset]);
+        let arr_ptr = builder.gep(ptr_ty, arr_ptr, &[offset]);
 
         // if the array_ptr is null select the scalar_ptr otherwise select the arr_ptr
-        let ptr = builder.select(is_arr_null, scalar_ptr, arr_ptr);
+        let ptr = builder.select(is_arr_null, meta, arr_ptr);
 
         //final load
-        builder.load(builder.cx.elem_ty(ptr_ty), ptr)
+        builder.load(ptr_ty, ptr)
     }
 }
 
@@ -299,16 +304,16 @@ impl CodegenCtx<'_, '_> {
 
         let fun_ty = cx.ty_func(
             &[
-                cx.ty_isize(),                             // offset
-                cx.ptr_ty(cx.fat_ptr(cx.ty_real(), true)), // voltages
-                cx.ptr_ty(cx.fat_ptr(cx.ty_real(), true)), // curents
-                cx.ptr_ty(cx.fat_ptr(cx.ty_real(), true)), // real paras
-                cx.ptr_ty(cx.fat_ptr(cx.ty_int(), true)),  // int paras
-                cx.ptr_ty(cx.fat_ptr(cx.ty_str(), true)),  // str paras
-                cx.ptr_ty(cx.fat_ptr(cx.ty_real(), true)), // real dependency_breaking
-                cx.ptr_ty(cx.fat_ptr(cx.ty_int(), true)),  // int dependency_breaking
-                cx.ptr_ty(cx.fat_ptr(cx.ty_real(), true)), // temperature
-                cx.ptr_ty(ret_ty),                         // ret
+                cx.ty_size(), // offset
+                cx.ty_ptr(),  // voltages
+                cx.ty_ptr(),  // curents
+                cx.ty_ptr(),  // real paras
+                cx.ty_ptr(),  // int paras
+                cx.ty_ptr(),  // str paras
+                cx.ty_ptr(),  // real dependency_breaking
+                cx.ty_ptr(),  // int dependency_breaking
+                cx.ty_ptr(),  // temperature
+                cx.ty_ptr(),  // ret
             ],
             cx.ty_void(),
         );
@@ -341,7 +346,7 @@ impl CodegenCtx<'_, '_> {
                     | ParamKind::HiddenState(_) => return BuilderVal::Undef,
                     ParamKind::Temperature => unsafe {
                         let temperature = llvm::LLVMGetParam(llfun, 8);
-                        codegen.read_fat_ptr_at(0, offset, temperature)
+                        codegen.read_fat_ptr_at(0, offset, temperature, cx.ty_double())
                     },
                     ParamKind::ParamGiven { .. } | ParamKind::PortConnected { .. } => true_val,
                     ParamKind::ParamSysFun(param) => {
@@ -404,7 +409,7 @@ impl CodegenCtx<'_, '_> {
             builder.select_bb(exit_bb);
 
             let out = llvm::LLVMGetParam(llfun, 9);
-            let out = builder.gep(out, &[offset]);
+            let out = builder.gep(ret_ty, out, &[offset]);
 
             let ret_val = intern.outputs[&PlaceKind::Var(spec.var)].unwrap();
             let ret_val = builder.values[ret_val].get(&builder);
@@ -461,7 +466,7 @@ impl CodegenCtx<'_, '_> {
             let given_id = intern.params.unwrap_index(&ParamKind::ParamGiven { param: *param });
             let given = unsafe {
                 let off = builder.cx.const_usize(param_given_offset + offset);
-                let ptr = builder.gep(param_given_ptr, &[off]);
+                let ptr = builder.gep(builder.cx.ty_c_bool(), param_given_ptr, &[off]);
                 let cbool = builder.load(builder.cx.ty_c_bool(), ptr);
                 builder.int_cmp(cbool, builder.cx.const_c_bool(false), llvm::IntPredicate::IntNE)
             };
@@ -469,7 +474,7 @@ impl CodegenCtx<'_, '_> {
             let val_id = intern.params.unwrap_index(&ParamKind::Param(*param));
             let val = unsafe {
                 let off = builder.cx.const_usize(offset);
-                let ptr = builder.gep(val_ptr, &[off]);
+                let ptr = builder.gep(llty, val_ptr, &[off]);
                 builder.load(llty, ptr)
             };
 
@@ -488,6 +493,7 @@ impl CodegenCtx<'_, '_> {
         val_ptr: &'ll llvm::Value,
         bounds_ptrs: Option<(&'ll llvm::Value, &'ll llvm::Value)>,
     ) {
+        let llty = lltype(&ty, builder.cx);
         for (i, (param, _)) in
             self.model_info.params.iter().filter(|(_, info)| info.ty == ty).enumerate()
         {
@@ -496,7 +502,7 @@ impl CodegenCtx<'_, '_> {
 
             unsafe {
                 let off = builder.cx.const_usize(i);
-                let ptr = builder.gep(val_ptr, &[off]);
+                let ptr = builder.gep(llty, val_ptr, &[off]);
                 builder.store(ptr, param_val)
             };
 
@@ -505,7 +511,7 @@ impl CodegenCtx<'_, '_> {
                     let param_min = intern.outputs[&PlaceKind::ParamMin(*param)].unwrap();
                     let param_min = builder.values[param_min].get(builder);
                     let off = builder.cx.const_usize(i);
-                    let ptr = builder.gep(min_ptr, &[off]);
+                    let ptr = builder.gep(llty, min_ptr, &[off]);
                     builder.store(ptr, param_min)
                 }
 
@@ -513,7 +519,7 @@ impl CodegenCtx<'_, '_> {
                     let param_max = intern.outputs[&PlaceKind::ParamMax(*param)].unwrap();
                     let param_max = builder.values[param_max].get(builder);
                     let off = builder.cx.const_usize(i);
-                    let ptr = builder.gep(max_ptr, &[off]);
+                    let ptr = builder.gep(llty, max_ptr, &[off]);
                     builder.store(ptr, param_max)
                 }
             }
@@ -526,7 +532,7 @@ impl CodegenCtx<'_, '_> {
         set: bool,
     ) -> (&'ll llvm::Value, &'ll llvm::Type) {
         let name = cx.local_callback_name();
-        let fun_ty = cx.ty_func(&[cx.ptr_ty(cx.ty_c_bool()), cx.ty_c_bool()], cx.ty_void());
+        let fun_ty = cx.ty_func(&[cx.ty_ptr(), cx.ty_c_bool()], cx.ty_void());
         let fun = cx.declare_int_fn(&name, fun_ty);
         unsafe {
             let bb = llvm::LLVMAppendBasicBlockInContext(cx.llcx, fun, UNNAMED);
@@ -572,7 +578,7 @@ impl CodegenCtx<'_, '_> {
 
             let dst = unsafe {
                 let off = builder.cx.const_usize(*off);
-                builder.gep(param_flags, &[off])
+                builder.gep(builder.cx.ty_c_bool(), param_flags, &[off])
             };
 
             *off += 1;
@@ -618,17 +624,17 @@ impl CodegenCtx<'_, '_> {
         let cx = unsafe { self.llbackend.new_ctx(self.literals, &module) };
 
         let (fun_names, fun_symbols) = interned_model.functions(&cx);
-        cx.export_array("functions", cx.ty_str(), &fun_names, true, true);
-        cx.export_array("functions.sym", cx.ty_str(), &fun_symbols, true, false);
+        cx.export_array("functions", cx.ty_ptr(), &fun_names, true, true);
+        cx.export_array("functions.sym", cx.ty_ptr(), &fun_symbols, true, false);
 
         let op_vars = interned_model.opvars(&cx);
-        cx.export_array("opvars", cx.ty_str(), &op_vars, true, true);
+        cx.export_array("opvars", cx.ty_ptr(), &op_vars, true, true);
 
         let nodes = interned_model.nodes(&cx);
-        cx.export_array("nodes", cx.ty_str(), &nodes, true, true);
+        cx.export_array("nodes", cx.ty_ptr(), &nodes, true, true);
 
         let module_name = cx.const_str(interned_model.module_name);
-        cx.export_val("module_name", cx.ty_str(), module_name, true);
+        cx.export_val("module_name", cx.ty_ptr(), module_name, true);
 
         interned_model.export_param_info(&cx, Type::Real);
         interned_model.export_param_info(&cx, Type::Integer);
@@ -636,14 +642,14 @@ impl CodegenCtx<'_, '_> {
 
         let fun_ty = cx.ty_func(
             &[
-                cx.ptr_ty(cx.ty_real()),   // real param values
-                cx.ptr_ty(cx.ty_int()),    // int param values
-                cx.ptr_ty(cx.ty_str()),    // str param values
-                cx.ptr_ty(cx.ty_real()),   // real param min
-                cx.ptr_ty(cx.ty_int()),    // int param min
-                cx.ptr_ty(cx.ty_real()),   // real param max
-                cx.ptr_ty(cx.ty_int()),    // int param max
-                cx.ptr_ty(cx.ty_c_bool()), // param_given/error
+                cx.ty_ptr(), // real param values
+                cx.ty_ptr(), // int param values
+                cx.ty_ptr(), // str param values
+                cx.ty_ptr(), // real param min
+                cx.ty_ptr(), // int param min
+                cx.ty_ptr(), // real param max
+                cx.ty_ptr(), // int param max
+                cx.ty_ptr(), // param_given/error
             ],
             cx.ty_void(),
         );
@@ -815,16 +821,16 @@ impl InternedModel<'_> {
         let params = self.param_info(cx, &ty);
 
         let sym = format!("params.{}", ty);
-        cx.export_array(&sym, cx.ty_str(), &params.names, true, true);
+        cx.export_array(&sym, cx.ty_ptr(), &params.names, true, true);
 
         let sym = format!("params.unit.{}", ty);
-        cx.export_array(&sym, cx.ty_str(), &params.units, true, false);
+        cx.export_array(&sym, cx.ty_ptr(), &params.units, true, false);
 
         let sym = format!("params.desc.{}", ty);
-        cx.export_array(&sym, cx.ty_str(), &params.descriptions, true, false);
+        cx.export_array(&sym, cx.ty_ptr(), &params.descriptions, true, false);
 
         let sym = format!("params.group.{}", ty);
-        cx.export_array(&sym, cx.ty_str(), &params.groups, true, false);
+        cx.export_array(&sym, cx.ty_ptr(), &params.groups, true, false);
     }
 }
 

--- a/verilogae/verilogae_py/Cargo.toml
+++ b/verilogae/verilogae_py/Cargo.toml
@@ -11,13 +11,13 @@ crate-type = ["cdylib"]
 name = "verilogae_py"
 
 [dependencies]
-pyo3-ffi = { version = "0.17", features = ["extension-module", "generate-import-lib"]}
+pyo3-ffi = { version = "0.18", features = ["extension-module", "generate-import-lib"]}
 verilogae_ffi = { version = "0.9.0-beta8", path = "../verilogae_ffi", default_features=false}
 libc = "0.2"
 
 [build-dependencies]
 
-pyo3-build-config = {version = "0.17", features = ["resolve-config"]}
+pyo3-build-config = {version = "0.18", features = ["resolve-config"]}
 
 
 [features]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.56"
 [dependencies]
 anyhow = "1.0"
 xshell = "0.2"
-xflags = "0.2"
+xflags = "0.3"
 md5 = "0.7"
 base_n = {version="1",path = "../lib/base_n"}
 # Avoid adding more dependencies to this crate

--- a/xtask/src/flags.rs
+++ b/xtask/src/flags.rs
@@ -3,25 +3,6 @@ xflags::xflags! {
 
     /// Run custom build command.
     cmd xtask {
-        default cmd help {
-            /// Print help information.
-            optional -h, --help
-        }
-
-        // cmd vendor{
-        //     optional --force
-        //     optional --no_upload
-        //     optional --check
-        // }
-
-        // cmd cache {
-        //     cmd prepare{}
-        //     cmd create{}
-        //     cmd upload{}
-        //     cmd fetch{}
-        //     cmd update{}
-        // }
-
         cmd verilogae{
             cmd build{
                 optional --force
@@ -51,14 +32,8 @@ pub struct Xtask {
 
 #[derive(Debug)]
 pub enum XtaskCmd {
-    Help(Help),
     Verilogae(Verilogae),
     GenMsvcrt(GenMsvcrt),
-}
-
-#[derive(Debug)]
-pub struct Help {
-    pub help: bool,
 }
 
 #[derive(Debug)]
@@ -90,7 +65,10 @@ pub struct Publish;
 pub struct GenMsvcrt;
 
 impl Xtask {
-    pub const HELP: &'static str = Self::HELP_;
+    #[allow(dead_code)]
+    pub fn from_env_or_exit() -> Self {
+        Self::from_env_or_exit_()
+    }
 
     #[allow(dead_code)]
     pub fn from_env() -> xflags::Result<Self> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -26,10 +26,6 @@ fn main() -> Result<()> {
 
     let flags = flags::Xtask::from_env()?;
     match flags.subcommand {
-        flags::XtaskCmd::Help(_) => {
-            println!("{}", flags::Xtask::HELP);
-            Ok(())
-        }
         flags::XtaskCmd::Verilogae(cmd) => cmd.run(&mut sh),
         flags::XtaskCmd::GenMsvcrt(cmd) => cmd.run(&sh),
     }


### PR DESCRIPTION
- Migrate to LLVM 15 and opaque pointers
- fix panic for current probes to trivially open branches (fixes #52, fixes #53, fixes #66)
- warn when using trivially open branches
- add basic logging
- add crash handler
- update build instructions
- bump dependencies
