### PR TITLE
Fix compile fails and crashes on `aarch64`

### DIFF
--- a/openvaf/llvm/src/initialization.rs
+++ b/openvaf/llvm/src/initialization.rs
@@ -125,7 +125,7 @@ unsafe fn configure_llvm(cg_opts: &[String], tg_opts: &[String]) {
     LLVMParseCommandLineOptions(
         llvm_args.len() as c_int,
         llvm_args.as_ptr(),
-        b"".as_ptr() as *const i8,
+        b"".as_ptr() as *const libc::c_char,
     );
 }
 

--- a/openvaf/mir_llvm/src/builder.rs
+++ b/openvaf/mir_llvm/src/builder.rs
@@ -607,7 +607,7 @@ impl<'ll> Builder<'_, '_, 'll> {
             Opcode::Feq => self.build_real_cmp(args, llvm::RealPredicate::RealOEQ),
             Opcode::Fne => self.build_real_cmp(args, llvm::RealPredicate::RealONE),
             Opcode::Bne | Opcode::Ine => self.build_int_cmp(args, llvm::IntPredicate::IntNE),
-            Opcode::FIcast => self.intrinsic(args, "llvm.llround.i32.f64"),
+            Opcode::FIcast => self.intrinsic(args, "llvm.lround.i32.f64"),
             Opcode::Seq => self.strcmp(args, false),
             Opcode::Sne => self.strcmp(args, true),
             Opcode::Sqrt => self.intrinsic(args, "llvm.sqrt.f64"),

--- a/openvaf/mir_llvm/src/intrinsics.rs
+++ b/openvaf/mir_llvm/src/intrinsics.rs
@@ -60,7 +60,7 @@ impl<'a, 'll> CodegenCx<'a, 'll> {
         }
 
         ifn!("strcmp", fn(t_str, t_str) -> t_i32);
-        ifn!("llvm.llround.i32.f64", fn(t_f64) -> t_i32);
+        ifn!("llvm.lround.i32.f64", fn(t_f64) -> t_i32);
 
         if name == "snprintf" {
             return Some(self.insert_intrinsic("snprintf", &[t_str, t_isize, t_str], t_i32, true));


### PR DESCRIPTION
We have tested the proposed changes on `x86_64` and `aarch64`, they work for both; we suggest merging them into the source.

This is the Dockerfile that has been used for testing:

```
# REPLACE "aarch64" BY "x86_64" IF NEEDED
FROM quay.io/pypa/manylinux2014_aarch64:latest

# user for non-root commands
RUN useradd -ms /bin/bash human

# build LLVM-15
RUN git clone --depth=1 --branch release/15.x https://github.com/llvm/llvm-project.git
RUN cd llvm-project \
    && mkdir build && cd build \
    && cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld" -DCMAKE_INSTALL_PREFIX=~/tools/llvm -DCMAKE_BUILD_TYPE=Release ../llvm \
    && make -j $(nproc) \
    && make install

ENV LLVM_CONFIG=~/tools/llvm/bin/llvm-config

# install rust
RUN yum group install "Development Tools" -y && \
    yum clean all

ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo
ENV PATH $CARGO_HOME/bin:$PATH

RUN mkdir -p "$CARGO_HOME" && mkdir -p "$RUSTUP_HOME" && \
    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable && \
    chmod -R a=rwX $CARGO_HOME

# set path variables
ENV PATH="$PATH:/root/tools/llvm/bin"
ENV LLVM_CONFIG=/root/tools/llvm/bin/llvm-config

# install Python3.8 https://gist.github.com/wpupru/deda1cd96ea242d9a790e50cd0c97e9f
RUN yum install wget gcc openssl-devel bzip2-devel libffi-devel -y
RUN cd /usr/src && \
    wget https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tgz && \
    tar xzf Python-3.8.0.tgz && \
    cd Python-3.8.0 && \
    ./configure --enable-optimizations && \
    make altinstall

RUN ln -s /usr/local/bin/python3.8 /usr/bin/python3 && \
    ln -s /usr/local/bin/pip3.8 /usr/bin/pip3

# download OpenVAF repository
RUN mkdir /io && \
    cd /io && \
    git clone https://github.com/iic-jku/OpenVAF


# sed -i 's/i8/libc::c_char/g' openvaf/llvm/src/initialization.rs && \
# sed -i 's/llround/lround/g' openvaf/mir_llvm/src/intrinsics.rs && \
# sed -i 's/llround/lround/g' openvaf/mir_llvm/src/builder.rs && \

# OpenVAF build
RUN cd /io/OpenVAF && \
    cargo build --release

# Python packages for compiling vae
#RUN pip3 install wheel

# VerilogAE build
#RUN cd /io/OpenVAF && \
#    cargo xtask verilogae build --manylinux
```